### PR TITLE
PID and RC tuning page update

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -182,9 +182,6 @@
 #endif
 
 #ifdef CLEANFLIGHT                      
-  #if defined PAGE2
-    #undef PAGE2
-  #endif  
 #endif
 
 #if defined(HARIKIRI) || defined(MULTIWII_V21)                     

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -656,14 +656,17 @@ const char configMsg05[] PROGMEM = "MAX SPEED";
 const char configMsg06[] PROGMEM = "MAH USED";
 const char configMsg07[] PROGMEM = "MAX AMPS";
 //-----------------------------------------------------------Page1
-const char configMsg10[] PROGMEM = "PID CONFIG";
-const char configMsg11[] PROGMEM = "ROLL";
-const char configMsg12[] PROGMEM = "PITCH";
-const char configMsg13[] PROGMEM = "YAW";
-const char configMsg14[] PROGMEM = "ALT";
-const char configMsg15[] PROGMEM = "GPS";
-const char configMsg16[] PROGMEM = "LEVEL";
-const char configMsg17[] PROGMEM = "MAG";
+const char configMsgPage01[] PROGMEM = "PID CONFIG";
+const char configMsgPID01[] PROGMEM  = "ROLL";
+const char configMsgPID02[] PROGMEM  = "PITCH";
+const char configMsgPID03[] PROGMEM  = "YAW";
+const char configMsgPID04[] PROGMEM  = "ALT";
+const char configMsgPID05[] PROGMEM  = "POS";
+const char configMsgPID06[] PROGMEM  = "POSR";
+const char configMsgPID07[] PROGMEM  = "NAVR";
+const char configMsgPID08[] PROGMEM  = "LEVEL";
+const char configMsgPID09[] PROGMEM  = "MAG";
+const char configMsgPID10[] PROGMEM  = "VEL";
 //-----------------------------------------------------------Page2
 const char configMsg20[] PROGMEM = "RC TUNING";
 const char configMsg21[] PROGMEM = "RC RATE";
@@ -827,13 +830,16 @@ const PROGMEM char * const menu_stats_item[] =
 
 const PROGMEM char * const menu_pid[] = 
 {   
-  configMsg11,
-  configMsg12,
-  configMsg13,
-  configMsg14,
-  configMsg15,
-  configMsg16,
-  configMsg17,
+  configMsgPID01,
+  configMsgPID02,
+  configMsgPID03,
+  configMsgPID04,
+  configMsgPID05,
+  configMsgPID06,
+  configMsgPID07,
+  configMsgPID08,
+  configMsgPID09,
+  configMsgPID10,
 };
 
 const PROGMEM char * const menu_rc[] = 
@@ -900,7 +906,7 @@ const PROGMEM char * const menu_alarm_item[] =
 const PROGMEM char * const menutitle_item[] = 
 {   
   configMsg00,
-  configMsg10,
+  configMsgPage01,
   configMsg20,
   configMsg30,
   configMsg40,

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -78,7 +78,7 @@
 #define MAGD 113+(30*6)
 
 #define LINE      30
-#define LINE_N(y) (LINE*(y))
+#define LINE_N(y) (LINE*(y-1))
 #define LINE01    0
 #define LINE02    30
 #define LINE03    60

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -30,6 +30,7 @@
 #define MAXPAGE 9
 
 #define PIDITEMS 10
+#define RCITEMS 7
 
 // RX CHANEL IN MwRcData table
 #define ROLLSTICK        0
@@ -72,9 +73,8 @@
 #define MAGI 107+(30*6)
 #define MAGD 113+(30*6)
 
-#define SAVEP 93+(30*9)
-
 #define LINE      30
+#define LINE_N(y) (LINE*(y))
 #define LINE01    0
 #define LINE02    30
 #define LINE03    60
@@ -91,6 +91,14 @@
 #define LINE14    390
 #define LINE15    420
 #define LINE16    450
+
+#define COLT      3
+#define COL1      11
+#define COL2      17
+#define COL3      23
+
+#define SAVEP_ROW 12
+#define SAVEP_POS LINE_N(SAVEP_ROW+2)+COLT
 
 /********************       For Sensors presence      *********************/
 #define ACCELEROMETER  1//0b00000001
@@ -130,7 +138,7 @@ uint8_t oldROW=0;
 // Config status and cursor location
 uint8_t screenlayout=0;
 uint8_t oldscreenlayout=0;
-uint8_t ROW=10;
+uint8_t ROW=SAVEP_ROW;
 uint8_t COL=3;
 int8_t configPage=1;
 uint8_t configMode=0;

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -30,7 +30,11 @@
 #define MAXPAGE 9
 
 #define PIDITEMS 10
+#ifdef CLEANFLIGHT
+#define RCITEMS 9
+#else
 #define RCITEMS 7
+#endif
 
 // RX CHANEL IN MwRcData table
 #define ROLLSTICK        0
@@ -423,12 +427,21 @@ LINE04+10 |DISPLAY_NEVER,   // APstatusPosition
 
 static uint8_t P8[PIDITEMS], I8[PIDITEMS], D8[PIDITEMS];
 
+#ifdef CLEANFLIGHT
+static uint8_t rcRate8,rcExpo8;
+static uint8_t pitchRate,rollRate,yawRate;
+static uint8_t dynThrPID;
+static uint8_t thrMid8;
+static uint8_t thrExpo8;
+static uint16_t tpa_breakpoint16;
+#else
 static uint8_t rcRate8,rcExpo8;
 static uint8_t rollPitchRate;
 static uint8_t yawRate;
 static uint8_t dynThrPID;
 static uint8_t thrMid8;
 static uint8_t thrExpo8;
+#endif
 
 
 static uint16_t  MwAccSmooth[3]={0,0,0};       // Those will hold Accelerator data
@@ -668,12 +681,25 @@ const char configMsgPID08[] PROGMEM  = "LEVEL";
 const char configMsgPID09[] PROGMEM  = "MAG";
 const char configMsgPID10[] PROGMEM  = "VEL";
 //-----------------------------------------------------------Page2
-const char configMsg20[] PROGMEM = "RC TUNING";
-const char configMsg21[] PROGMEM = "RC RATE";
-const char configMsg22[] PROGMEM = "EXPONENTIAL";
-const char configMsg23[] PROGMEM = "ROLL PITCH RATE";
-const char configMsg24[] PROGMEM = "YAW RATE";
-const char configMsg25[] PROGMEM = "THROTTLE PID ATT";
+const char configMsgPage02[] PROGMEM = "RC TUNING";
+const char configMsgRC01[] PROGMEM = "RC RATE";
+const char configMsgRC02[] PROGMEM = "RC EXPO";
+#ifdef CLEANFLIGHT
+const char configMsgRC03[] PROGMEM = "PITCH RATE";
+const char configMsgRC04[] PROGMEM = "ROLL RATE";
+const char configMsgRC05[] PROGMEM = "YAW RATE";
+const char configMsgRC06[] PROGMEM = "THROTTLE MIDPOINT";
+const char configMsgRC07[] PROGMEM = "THROTTLE EXPO";
+const char configMsgRC08[] PROGMEM = "THROTTLE PID ATT";
+const char configMsgRC09[] PROGMEM = "TPA BREAKEPOINT";
+#else
+const char configMsgRC03[] PROGMEM = "ROLL PITCH RATE";
+const char configMsgRC04[] PROGMEM = "YAW RATE";
+const char configMsgRC05[] PROGMEM = "THROTTLE PID ATT";
+const char configMsgRC06[] PROGMEM = "THROTTLE MIDPOINT";
+const char configMsgRC07[] PROGMEM = "THROTTLE EXPO";
+#endif
+
 //-----------------------------------------------------------Page3
 const char configMsg30[] PROGMEM = "VOLTAGE";
 const char configMsg31[] PROGMEM = "DISPLAY MAIN VOLTS";
@@ -844,11 +870,17 @@ const PROGMEM char * const menu_pid[] =
 
 const PROGMEM char * const menu_rc[] = 
 {   
-  configMsg21,
-  configMsg22,
-  configMsg23,
-  configMsg24,
-  configMsg25,
+  configMsgRC01,
+  configMsgRC02,
+  configMsgRC03,
+  configMsgRC04,
+  configMsgRC05,
+  configMsgRC06,
+  configMsgRC07,
+  #ifdef CLEANFLIGHT
+  configMsgRC08,
+  configMsgRC09,
+  #endif
 };
 
 const PROGMEM char * const menu_bat[] = 
@@ -907,7 +939,7 @@ const PROGMEM char * const menutitle_item[] =
 {   
   configMsg00,
   configMsgPage01,
-  configMsg20,
+  configMsgPage02,
   configMsg30,
   configMsg40,
   configMsg50,

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -893,43 +893,51 @@ void displayDirectionToHome(void)
 void displayCursor(void)
 {
   int cursorpos;
-  if(ROW==10){
-    if(COL==3) cursorpos=SAVEP+16-1;    // page
-    if(COL==1) cursorpos=SAVEP-1;       // exit
-    if(COL==2) cursorpos=SAVEP+6-1;     // save/exit
+  if(ROW==SAVEP_ROW){
+    if(COL==3) cursorpos=SAVEP_POS+16-1;    // page
+    if(COL==1) cursorpos=SAVEP_POS-1;       // exit
+    if(COL==2) cursorpos=SAVEP_POS+6-1;     // save/exit
   }
-  if(ROW<10)
+  if(ROW<SAVEP_ROW)
     {
 #ifdef PAGE1
     if(configPage==1){
-      if (ROW==8) ROW=10;
-      if (ROW==9) ROW=7;
-      if(COL==1) cursorpos=(ROW+2)*30+10;
-      if(COL==2) cursorpos=(ROW+2)*30+10+6;
-      if(COL==3) cursorpos=(ROW+2)*30+10+6+6;
+      if (ROW>PIDITEMS){
+		  if (oldROW==SAVEP_ROW)
+		    ROW=PIDITEMS;
+		  else
+		    ROW=SAVEP_ROW;
+	  }
+      if(COL==1) cursorpos=LINE_N(ROW+2)+COL1-1;
+      if(COL==2) cursorpos=LINE_N(ROW+2)+COL2-1;
+      if(COL==3) cursorpos=LINE_N(ROW+2)+COL3-1;
      }
 #endif
 #ifdef PAGE2
     if(configPage==2){
       COL=3;
-      if (ROW==6) ROW=10;
-      if (ROW==9) ROW=5;
-      cursorpos=(ROW+2)*30+10+6+6;
+      if (ROW>RCITEMS){
+        if (oldROW==SAVEP_ROW)
+          ROW=RCITEMS;
+        else
+          ROW=SAVEP_ROW;
+      }
+      cursorpos=LINE_N(ROW+2)+COL3-1;
       }
 #endif
 #ifdef PAGE3      
     if(configPage==3){
       COL=3;
-      if (ROW==8) ROW=10;
-      if (ROW==9) ROW=7;
+      if (ROW==8) ROW=SAVEP_ROW;
+      if (ROW==SAVEP_ROW-1) ROW=7;
       cursorpos=(ROW+2)*30+10+6+6;     
       }
 #endif
 #ifdef PAGE4      
     if(configPage==4){
       COL=3;
-      if (ROW==7) ROW=10;
-      if (ROW==9) ROW=6;
+      if (ROW==7) ROW=SAVEP_ROW;
+      if (ROW==SAVEP_ROW-1) ROW=6;
       cursorpos=(ROW+2)*30+10+6+6;
       }    
 #endif
@@ -937,21 +945,20 @@ void displayCursor(void)
     if(configPage==5)
       {  
       COL=3;
-      if (ROW==9) ROW=5;
-      if (ROW==6) ROW=10;
+      if (ROW==SAVEP_ROW-1) ROW=5;
+      if (ROW==6) ROW=SAVEP_ROW;
       cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif
 #ifdef PAGE6      
     if(configPage==6)
       {  
-        if (ROW==9){
+        if (ROW>8){
           if (oldROW==8)
-            ROW=10;
+            ROW=SAVEP_ROW;
           else
             ROW=8;
         }
-        oldROW=ROW;
         COL=3;
       cursorpos=(ROW+2)*30+10+6+6;
       }
@@ -960,8 +967,8 @@ void displayCursor(void)
     if(configPage==7)
       {  
       COL=3;
-      if (ROW==9) ROW=5;
-      if (ROW==6) ROW=10;
+      if (ROW==SAVEP_ROW-1) ROW=5;
+      if (ROW==6) ROW=SAVEP_ROW;
        cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif
@@ -969,8 +976,8 @@ void displayCursor(void)
     if(configPage==8)
       {  
       COL=3;
-      if (ROW==9) ROW=3;
-      if (ROW==4) ROW=10;
+      if (ROW==SAVEP_ROW-1) ROW=3;
+      if (ROW==4) ROW=SAVEP_ROW;
        cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif     
@@ -978,12 +985,13 @@ void displayCursor(void)
     if(configPage==9)
       {  
       COL=3;
-      if (ROW==9) ROW=6;
-      if (ROW==7) ROW=10;
+      if (ROW==SAVEP_ROW-1) ROW=6;
+      if (ROW==7) ROW=SAVEP_ROW;
        cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif     
   }
+  oldROW=ROW;
   if(timer.Blink10hz)
     screen[cursorpos] = SYM_CURSOR;
 }
@@ -993,10 +1001,10 @@ void displayConfigScreen(void)
 {
   strcpy_P(screenBuffer, (char*)pgm_read_word(&(menutitle_item[configPage])));
   MAX7456_WriteString(screenBuffer, 35);
-  MAX7456_WriteString_P(configMsgEXT, SAVEP);    //EXIT
+  MAX7456_WriteString_P(configMsgEXT, SAVEP_POS);    //EXIT
   if(!previousarmedstatus) {
-    MAX7456_WriteString_P(configMsgSAVE, SAVEP+6);  //SaveExit
-    MAX7456_WriteString_P(configMsgPGS, SAVEP+16); //<Page>
+    MAX7456_WriteString_P(configMsgSAVE, SAVEP_POS+6);  //SaveExit
+    MAX7456_WriteString_P(configMsgPGS, SAVEP_POS+16); //<Page>
   }
 
   if(configPage==0)
@@ -1057,9 +1065,10 @@ void displayConfigScreen(void)
       if (Y>6){
         X=X-2;
       }
-      MAX7456_WriteString(itoa(P8[Y],screenBuffer,10),ROLLP+(X*30));
-      MAX7456_WriteString(itoa(I8[Y],screenBuffer,10),ROLLI+(X*30));
-      MAX7456_WriteString(itoa(D8[Y],screenBuffer,10),ROLLD+(X*30));
+
+      MAX7456_WriteString(itoa(P8[X],screenBuffer,10),LINE_N(X+3)+COL1);
+      MAX7456_WriteString(itoa(I8[X],screenBuffer,10),LINE_N(X+3)+COL2);
+      MAX7456_WriteString(itoa(D8[X],screenBuffer,10),LINE_N(X+3)+COL3);
     }
 
 /*
@@ -1095,9 +1104,9 @@ void displayConfigScreen(void)
 //    MAX7456_WriteString_P(configMsg17, MAGT);
     MAX7456_WriteString(itoa(P8[8],screenBuffer,10),MAGP);
 */
-    MAX7456_WriteString("P",71);
-    MAX7456_WriteString("I",77);
-    MAX7456_WriteString("D",83);
+    MAX7456_WriteString("P",LINE02+COL1);
+    MAX7456_WriteString("I",LINE02+COL2);
+    MAX7456_WriteString("D",LINE02+COL3);
   }
 #else
     if(configPage == 1)configPage+=menudir;

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1109,23 +1109,29 @@ void displayConfigScreen(void)
 #ifdef PAGE2
   if(configPage==2)
   {
-    for(uint8_t X=0; X<=4; X++) {
+    for(uint8_t X=0; X<RCITEMS; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_rc[X])));
-      MAX7456_WriteString(screenBuffer, ROLLT+ (X*30));
+      MAX7456_WriteString(screenBuffer, LINE_N(3+X)+COLT);
     }
-
-    //    MAX7456_WriteString_P(configMsg20, 35);
-//    MAX7456_WriteString_P(configMsg21, ROLLT);
-    MAX7456_WriteString(itoa(rcRate8,screenBuffer,10),ROLLD);
-//    MAX7456_WriteString_P(configMsg22, PITCHT);
-    MAX7456_WriteString(itoa(rcExpo8,screenBuffer,10),PITCHD);
-//    MAX7456_WriteString_P(configMsg23, YAWT);
-    MAX7456_WriteString(itoa(rollPitchRate,screenBuffer,10),YAWD);
-//    MAX7456_WriteString_P(configMsg24, ALTT);
-    MAX7456_WriteString(itoa(yawRate,screenBuffer,10),ALTD);
-//    MAX7456_WriteString_P(configMsg25, VELT);
-    MAX7456_WriteString(itoa(dynThrPID,screenBuffer,10),VELD);
-
+    #ifdef CLEANFLIGHT
+    MAX7456_WriteString(itoa(rcRate8,          screenBuffer,10),LINE04+COL3);
+    MAX7456_WriteString(itoa(rcExpo8,          screenBuffer,10),LINE05+COL3);
+    MAX7456_WriteString(itoa(pitchRate,        screenBuffer,10),LINE06+COL3);
+    MAX7456_WriteString(itoa(rollRate,         screenBuffer,10),LINE07+COL3);
+    MAX7456_WriteString(itoa(yawRate,          screenBuffer,10),LINE08+COL3);
+    MAX7456_WriteString(itoa(thrMid8,          screenBuffer,10),LINE09+COL3);
+    MAX7456_WriteString(itoa(thrExpo8,         screenBuffer,10),LINE10+COL3);
+    MAX7456_WriteString(itoa(dynThrPID,        screenBuffer,10),LINE11+COL3);
+    MAX7456_WriteString(itoa(tpa_breakpoint16, screenBuffer,10),LINE12+COL3);
+    #else
+    MAX7456_WriteString(itoa(rcRate8,          screenBuffer,10),LINE04+COL3);
+    MAX7456_WriteString(itoa(rcExpo8,          screenBuffer,10),LINE05+COL3);
+    MAX7456_WriteString(itoa(rollPitchRate,    screenBuffer,10),LINE06+COL3);
+    MAX7456_WriteString(itoa(yawRate,          screenBuffer,10),LINE07+COL3);
+    MAX7456_WriteString(itoa(dynThrPID,        screenBuffer,10),LINE08+COL3);
+    MAX7456_WriteString(itoa(thrMid8,          screenBuffer,10),LINE09+COL3);
+    MAX7456_WriteString(itoa(thrExpo8,         screenBuffer,10),LINE10+COL3);
+    #endif
   }
  #else
     if(configPage == 2)configPage+=menudir; 

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -908,9 +908,9 @@ void displayCursor(void)
 		  else
 		    ROW=SAVEP_ROW;
 	  }
-      if(COL==1) cursorpos=LINE_N(ROW+2)+COL1-1;
-      if(COL==2) cursorpos=LINE_N(ROW+2)+COL2-1;
-      if(COL==3) cursorpos=LINE_N(ROW+2)+COL3-1;
+      if(COL==1) cursorpos=LINE_N(3+ROW)+COL1-1;
+      if(COL==2) cursorpos=LINE_N(3+ROW)+COL2-1;
+      if(COL==3) cursorpos=LINE_N(3+ROW)+COL3-1;
      }
 #endif
 #ifdef PAGE2
@@ -922,7 +922,7 @@ void displayCursor(void)
         else
           ROW=SAVEP_ROW;
       }
-      cursorpos=LINE_N(ROW+2)+COL3-1;
+      cursorpos=LINE_N(3+ROW)+COL3-1;
       }
 #endif
 #ifdef PAGE3      
@@ -1053,55 +1053,16 @@ void displayConfigScreen(void)
   {
     for(uint8_t X=0; X<PIDITEMS; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_pid[X])));
-      MAX7456_WriteString(screenBuffer, LINE_N(3+X)+COLT);
-    }
-   
-//    MAX7456_WriteString_P(configMsg10, 35);
-//    MAX7456_WriteString_P(configMsg11, ROLLT);
 
-    for(uint8_t X=0; Y<PIDITEMS; X++) {      
-
-      MAX7456_WriteString(itoa(P8[X],screenBuffer,10),LINE_N(3+X)+COL1);
-      MAX7456_WriteString(itoa(I8[X],screenBuffer,10),LINE_N(3+X)+COL2);
-      MAX7456_WriteString(itoa(D8[X],screenBuffer,10),LINE_N(3+X)+COL3);
+      MAX7456_WriteString(screenBuffer,               LINE_N(4+X)+COLT);
+      MAX7456_WriteString(itoa(P8[X],screenBuffer,10),LINE_N(4+X)+COL1);
+      MAX7456_WriteString(itoa(I8[X],screenBuffer,10),LINE_N(4+X)+COL2);
+      MAX7456_WriteString(itoa(D8[X],screenBuffer,10),LINE_N(4+X)+COL3);
     }
 
-/*
-    MAX7456_WriteString(itoa(P8[0],screenBuffer,10),ROLLP);
-    MAX7456_WriteString(itoa(I8[0],screenBuffer,10),ROLLI);
-    MAX7456_WriteString(itoa(D8[0],screenBuffer,10),ROLLD);
-
-//    MAX7456_WriteString_P(configMsg12, PITCHT);
-    MAX7456_WriteString(itoa(P8[1],screenBuffer,10), PITCHP);
-    MAX7456_WriteString(itoa(I8[1],screenBuffer,10), PITCHI);
-    MAX7456_WriteString(itoa(D8[1],screenBuffer,10), PITCHD);
-
-//    MAX7456_WriteString_P(configMsg13, YAWT);
-    MAX7456_WriteString(itoa(P8[2],screenBuffer,10),YAWP);
-    MAX7456_WriteString(itoa(I8[2],screenBuffer,10),YAWI);
-    MAX7456_WriteString(itoa(D8[2],screenBuffer,10),YAWD);
-
-//    MAX7456_WriteString_P(configMsg14, ALTT);
-    MAX7456_WriteString(itoa(P8[3],screenBuffer,10),ALTP);
-    MAX7456_WriteString(itoa(I8[3],screenBuffer,10),ALTI);
-    MAX7456_WriteString(itoa(D8[3],screenBuffer,10),ALTD);
-
-//    MAX7456_WriteString_P(configMsg15, VELT);
-    MAX7456_WriteString(itoa(P8[4],screenBuffer,10),VELP);
-    MAX7456_WriteString(itoa(I8[4],screenBuffer,10),VELI);
-    MAX7456_WriteString(itoa(D8[4],screenBuffer,10),VELD);
-
-//    MAX7456_WriteString_P(configMsg16, LEVT);
-    MAX7456_WriteString(itoa(P8[7],screenBuffer,10),LEVP);
-    MAX7456_WriteString(itoa(I8[7],screenBuffer,10),LEVI);
-    MAX7456_WriteString(itoa(D8[7],screenBuffer,10),LEVD);
-
-//    MAX7456_WriteString_P(configMsg17, MAGT);
-    MAX7456_WriteString(itoa(P8[8],screenBuffer,10),MAGP);
-*/
-    MAX7456_WriteString("P",LINE02+COL1);
-    MAX7456_WriteString("I",LINE02+COL2);
-    MAX7456_WriteString("D",LINE02+COL3);
+    MAX7456_WriteString("P",LINE03+COL1);
+    MAX7456_WriteString("I",LINE03+COL2);
+    MAX7456_WriteString("D",LINE03+COL3);
   }
 #else
     if(configPage == 1)configPage+=menudir;
@@ -1111,7 +1072,7 @@ void displayConfigScreen(void)
   {
     for(uint8_t X=0; X<RCITEMS; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_rc[X])));
-      MAX7456_WriteString(screenBuffer, LINE_N(3+X)+COLT);
+      MAX7456_WriteString(screenBuffer, LINE_N(4+X)+COLT);
     }
     #ifdef CLEANFLIGHT
     MAX7456_WriteString(itoa(rcRate8,          screenBuffer,10),LINE04+COL3);

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1051,24 +1051,19 @@ void displayConfigScreen(void)
 #ifdef PAGE1
   if(configPage==1)
   {
-    for(uint8_t X=0; X<=6; X++) {
+    for(uint8_t X=0; X<PIDITEMS; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_pid[X])));
-      MAX7456_WriteString(screenBuffer, ROLLT+ (X*30));
+      MAX7456_WriteString(screenBuffer, LINE_N(3+X)+COLT);
     }
    
 //    MAX7456_WriteString_P(configMsg10, 35);
 //    MAX7456_WriteString_P(configMsg11, ROLLT);
 
-    for(uint8_t Y=0; Y<=8; Y++) {      
-      if (Y==5) Y=7;
-      uint8_t X=Y;
-      if (Y>6){
-        X=X-2;
-      }
+    for(uint8_t X=0; Y<PIDITEMS; X++) {      
 
-      MAX7456_WriteString(itoa(P8[X],screenBuffer,10),LINE_N(X+3)+COL1);
-      MAX7456_WriteString(itoa(I8[X],screenBuffer,10),LINE_N(X+3)+COL2);
-      MAX7456_WriteString(itoa(D8[X],screenBuffer,10),LINE_N(X+3)+COL3);
+      MAX7456_WriteString(itoa(P8[X],screenBuffer,10),LINE_N(3+X)+COL1);
+      MAX7456_WriteString(itoa(I8[X],screenBuffer,10),LINE_N(3+X)+COL2);
+      MAX7456_WriteString(itoa(D8[X],screenBuffer,10),LINE_N(3+X)+COL3);
     }
 
 /*

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -532,14 +532,10 @@ void serialMenuCommon()
     if(configPage>MAXPAGE) configPage = MINPAGE;
 #ifdef PAGE1
 	if(configPage == 1) {
-	  if(ROW >= 1 && ROW <= 7) {
-            uint8_t MODROW=ROW-1;
-            if (ROW>5){
-              MODROW=ROW+1;
-            }
-  	    if(COL==1) P8[MODROW]=P8[MODROW]+menudir;
-	    if(COL==2) I8[MODROW]=I8[MODROW]+menudir;
-	    if(COL==3) D8[MODROW]=D8[MODROW]+menudir;
+	  if(ROW >= 1 && ROW <= PIDITEMS) {
+	    if(COL==1) P8[ROW-1] += menudir;
+	    if(COL==2) I8[ROW-1] += menudir;
+	    if(COL==3) D8[ROW-1] += menudir;
 	  }
 	}
 #endif
@@ -847,6 +843,4 @@ void headSerialRequest (void) {
   Serial.write('<');
   
 }
-
-
 

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -488,15 +488,15 @@ void handleRawRC() {
 	if(ROW<1)
 	  ROW=1;
         if(configPage == 0) {
-          ROW=10;
+          ROW=SAVEP_ROW;
         }
       }
       else if(configMode&&(MwRcData[PITCHSTICK]<MINSTICK)) // MOVE DOWN
       {
 	waitStick = 1;
 	ROW++;
-	if(ROW>10)
-	  ROW=10;
+	if(ROW>SAVEP_ROW)
+	  ROW=SAVEP_ROW;
       }
       else if(!previousarmedstatus&&configMode&&(MwRcData[YAWSTICK]<MINSTICK)) // DECREASE
       {
@@ -524,7 +524,7 @@ void handleRawRC() {
 
 void serialMenuCommon()
   {
-    if((ROW==10)&&(COL==3)) {
+    if((ROW==SAVEP_ROW)&&(COL==3)) {
       constrain(menudir,-1,1);
       configPage=configPage+menudir;
     }
@@ -623,8 +623,8 @@ void serialMenuCommon()
 	  if(ROW==6) Settings[S_AMPERAGE_ALARM]=Settings[S_AMPERAGE_ALARM]+menudir;
 	}
 #endif
-  	if((ROW==10)&&(COL==1)) configExit();
-	if((ROW==10)&&(COL==2)) configSave();
+  	if((ROW==SAVEP_ROW)&&(COL==1)) configExit();
+	if((ROW==SAVEP_ROW)&&(COL==2)) configSave();
 }
 
 void serialMSPreceive()
@@ -701,7 +701,7 @@ void serialMSPreceive()
 void configExit()
 {
   configPage=1;
-  ROW=10;
+  ROW=SAVEP_ROW;
   COL=3;
   configMode=0;
   //waitStick=3;


### PR DESCRIPTION
Adds all the PID and RC tuning parameters supported by MSP to the PID config and RC tuning pages. This solves the PID menu bug mentioned on the roadmap. The RC tuning page also supports Cleanflight specific parameters when compiled with CLEANFLIGHT defined (should solve issue #9.) Did some refactoring on the code i touched that hopefully will not cause any issues.