### PR TITLE
LOW SAT warning /  glidescope tweak

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -67,7 +67,7 @@
 
 /********************       GPS settings      *********************/
 #define MINSATFIX 5                // Number of sats required for a fix. 5 minimum. More = better
-#define GPSACTIVECHECK 4           // Sets GPS fix to zero if no GPS data for more than x secs. Sets GPS fix to zero
+#define GPSACTIVECHECK 6           // Sets GPS fix to zero if no GPS data for more than x secs. Sets GPS fix to zero
 #define DISP_LOW_SATS_WARNING      // Displays low sat warning in addition to flashing sat indicator
 
 /********************       AIRCRAFT type=FIXEDWING settings      *********************/
@@ -147,6 +147,7 @@
 //#define I2CERROR 3                // Autodisplay Mutltiwii I2C errors if exceeds specified count 
 //#define SHORTSTATS                // Display only timer on flight summary 
 //#define FASTMSP                   // Enable for soft serial / slow baud rates if don't need GPS/BARO/HORIZON data. Speeds up remainder
+#define NOTHROTTLESPACE           // Enable to remove space between throttle symbol and the data
 #define DISP_LOW_VOLTS_WARNING      // Enable prominent low voltage warning text
 #define FORCE_DISP_LOW_VOLTS        // Enable display low voltage warning override for screen layouts where its disabled
 #define APINDICATOR                 // Enable to display AUTOPILOT instead of RTH distance 

--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -4,8 +4,13 @@
 /********************       OSD HARDWARE settings      *********************/
 //Choose ONLY ONE option:
 #define MINIMOSD                    // Uncomment this if using standard MINIMOSD hardware (default for 95% of boards) 
-//#define WITESPYV1.1               // Uncomment this if using Witespy V1.1 OSD, select this to correct for mislabelled bat1 and bat 2. Alsoe uses alternative resistors / pinouts. 
+//#define WITESPYV1.1               // Uncomment this if using Witespy V1.1 OSD, select this to correct for both swapped bat1/bat 2 and to also use alternative resistors / pinouts.  
 //#define RUSHDUINO                 // Uncomment this if using Rushduino
+
+// NOTE-some of the popular RTFQ boards have alternative bat1/bat2 pins and voltage measuring resistors
+// If having difficulties, first select default MINIMOSD as above, then use the following to correct: 
+// #define SWAPVOLTAGEPINS          // For RTFQ boards with batt voltage appearing on vid voltage
+// #define ALTERNATEDIVIDERS        // For RFTQ boards with voltage unable to be adjusted high enough
 
 
 /********************       CONTROLLER SOFTWARE      *********************/
@@ -17,7 +22,7 @@
 //#define CLEANFLIGHT180            // Uncomment this if you are using CLEANFLIGHT versions up to and including 1.8.0
 //#define CLEANFLIGHT               // Uncomment this if you are using CLEANFLIGHT versions 1.8.1 onwards (No RC adjustments menu)
 //#define HARIKIRI                  // Uncomment this if you are using HARIKIRI (for BOXNAMES compatibility)
-//#define NOCONTROLLER              // Uncomment this if you are using GPSOSD
+//#define NOCONTROLLER              // Uncomment this if you are using GPSOSD or not using a flight controller
 
 
 /********************       AIRCRAFT TYPE settings      *********************/
@@ -42,6 +47,9 @@
 
 
 /********************       OSD SCREEN SWITCH settings      *********************/
+// This functionality enables :
+// a, 2 different screen layouts to be selected using the Flight controller "OSD_SWITCH" feature or
+// b, 2 or 3 different screen layouts to be selected using a specificed RC channel assigned to a TX switch
 //Choose ONLY ONE option:
 //#define OSD_SWITCH                // Uses original 2 way screen switch using OSD Switch via Flight Controller. MUST Ensure enabled on flight controller - e.g. #define OSD_SWITCH on multiwii
 #define OSD_SWITCH_RC               // Enables GUI to use 2 way OSD_SWITCh or 3 way screen switch using RC data. Specify channel on GUI (range 0-7 AUX1=4 AUX4=7)
@@ -59,14 +67,16 @@
 
 /********************       GPS settings      *********************/
 #define MINSATFIX 5                // Number of sats required for a fix. 5 minimum. More = better
-//#define GPSACTIVECHECK 4           // Sets GPS fix to zero if no GPS data for more than x secs. Sets GPS fix to zero
+#define GPSACTIVECHECK 4           // Sets GPS fix to zero if no GPS data for more than x secs. Sets GPS fix to zero
+#define DISP_LOW_SATS_WARNING      // Displays low sat warning in addition to flashing sat indicator
 
 /********************       AIRCRAFT type=FIXEDWING settings      *********************/
 // **ONLY** valid when using fixed wing
 //#define USEMAGHEADING             // Only undefine this use MAG for FW heading instead of GPS (requires controller with MAG sensor) 
 //#define USEBAROALTITUDE           // ***Recommend*** to undefine this if you have a BARO to use BARO for FW altitude instead of GPS (requires controller with BARO sensor) 
-//#define USEGLIDESCOPE 30          // Enables ILS glidescope where 30 = 3.0° glidescope with 0.5 deg gradiented scope scale
+//#define USEGLIDESCOPE 40          // Enables ILS glidescope where 40 = 4.0° glidescope. 1.0 deg gradiented scope scale
 //#define DISABLEGPSALTITUDERESET   // Disables automatic reset of GPS Altitude to zero at arm for FC that already provide this functionality. 
+
 
 /********************       GPS OSD settings      *********************/
 // **ONLY** FOR STANDALONE GPS MODE WITH NO FLIGHT CONTROLLER
@@ -95,11 +105,11 @@
 
 
 /********************       STARTUP settings      *********************/
-#define INTRO_VERSION               "MW-OSD - R1.4PRE" // Call the OSD something else if you prefer. KVOSD is not permitted - LOL. 
+//#define INTRO_VERSION               "SHIKI-OSD - NAZA DEV01" // Call the OSD something else if you prefer. KVOSD is not permitted - LOL. 
 //#define INTRO_CALLSIGN            // Enable to display callsign at startup
 //#define INTRO_TIMEZONE            // Enable to display timezone at startup - if GPS TIME is enabled
 //#define INTRO_DELAY 5             // Seconds intro screen should show for. Default is 10 
-//#define INTRO_MENU                  // Enable to display TX stick MENU 
+#define INTRO_MENU                  // Enable to display TX stick MENU 
 //#define STARTUPDELAY 2000         // Enable alternative startup delay (in ms) to allow MAX chip voltage to rise fully and initialise before configuring 
 
 
@@ -221,18 +231,27 @@
     # define MAX7456SELECT 6         // ss
     # define MAX7456RESET  10        // RESET
 #endif
+
 #ifdef WITESPYV1.1                     
+    #define SWAPVOLTAGEPINS
+    #define ALTERNATEDIVIDERS
+#endif
+
+#ifdef SWAPVOLTAGEPINS                     
     #define VOLTAGEPIN    A2
     #define VIDVOLTAGEPIN A0
-    #define DIVIDER1v1      0.0002      // Voltage divider for 1.1v reference. 
-    #define DIVIDER5v       0.0008      // Voltage divider for 5v reference. 
 #else                                  
     #define VOLTAGEPIN    A0
     #define VIDVOLTAGEPIN A2
+#endif
+
+#ifdef ALTERNATEDIVIDERS                     
+    #define DIVIDER1v1      0.0002      // Voltage divider for 1.1v reference. 
+    #define DIVIDER5v       0.0008      // Voltage divider for 5v reference. 
+#else                                  
     #define DIVIDER1v1      0.0001      // Voltage divider for 1.1v reference. Use 0.0001 default unless advised otherwise.
     #define DIVIDER5v       0.0005      // Voltage divider for 5v reference. Use 0.0005 default unless advised otherwise.
 #endif
-
 
 /********************  GPS OSD rule definitions  *********************/
 #if defined MTK_BINARY16
@@ -260,6 +279,10 @@
 #endif
 
 #if defined NMEA
+  #define GPSOSD
+#endif
+
+#if defined NAZA
   #define GPSOSD
 #endif
 

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -588,7 +588,6 @@ uint16_t flyingTime=0;
   uint8_t  GPS_active=5; 
   uint8_t  GPS_fix_HOME=0;
   const char satnogps_text[] PROGMEM = " NO GPS ";
-  const char satlow_text[]   PROGMEM = "LOW SATS";
 #endif
 
 
@@ -662,10 +661,12 @@ const char armed_text[] PROGMEM     = " ARMED";
 const char APRTHtext[] PROGMEM      = "AUTO RTH";
 const char APHOLDtext[] PROGMEM     = "AUTO HOLD";
 const char APWAYPOINTtext[] PROGMEM = " MISSION";
+const char satlow_text[] PROGMEM    = "LOW SATS";
 //const char APLANDtext[] PROGMEM = "LANDING";
 #ifdef DISP_LOW_VOLTS_WARNING
 const char lowvolts_text[] PROGMEM  = "LOW VOLTS";
 #endif
+
 
 // For Intro
 #ifdef INTRO_VERSION

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -22,7 +22,7 @@ This work is based on the following open source work :-
 */
 
 //------------------------------------------------------------------------
-#define MEMCHECK 3 // to enable memeory checking and set debug[x] value
+//#define MEMCHECK 3 // to enable memeory checking and set debug[x] value
 #if 1
 __asm volatile ("nop");
 #endif
@@ -344,7 +344,7 @@ void loop()
           displayDistanceToHome();
           displayAngleToHome();
           #ifdef USEGLIDESCOPE
-            displayfwglidescope();
+            // displayfwglidescope(); //note hook for this is in display horizon function
           #endif //USEGLIDESCOPE  
           displayGPS_speed();
           displayGPSPosition();  
@@ -384,6 +384,7 @@ void loop()
       if (GPS_frame_timer>GPSACTIVECHECK){
         GPS_frame_timer=GPSACTIVECHECK+1;
         GPS_fix=0;
+        GPS_numSat=0;
       }
     #endif // GPSACTIVECHECK 
     if (Settings[S_AMPER_HOUR]) 

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -493,23 +493,30 @@ void displayCurrentThrottle(void)
   if(!fieldIsVisible(CurrentThrottlePosition))
     return;
 
+  #ifndef NOTHROTTLESPACE
+    #define THROTTLESPACE 1
+  #else
+    #define THROTTLESPACE 0
+    screenBuffer[1]=' ';
+  #endif  
   if (MwRcData[THROTTLESTICK] > HighT) HighT = MwRcData[THROTTLESTICK] -5;
   if (MwRcData[THROTTLESTICK] < LowT) LowT = MwRcData[THROTTLESTICK];      // Calibrate high and low throttle settings  --defaults set in GlobalVariables.h 1100-1900
   if(!armed) {
-    screenBuffer[2]=' ';
-    screenBuffer[3]=' ';
-    screenBuffer[4]='-';
-    screenBuffer[5]='-';
+    screenBuffer[0+THROTTLESPACE]=' ';
+    screenBuffer[1+THROTTLESPACE]=' ';
+    screenBuffer[2+THROTTLESPACE]='-';
+    screenBuffer[3+THROTTLESPACE]='-';
+    screenBuffer[4+THROTTLESPACE]=' ';
+
   }
   else
   {
     int CurThrottle = map(MwRcData[THROTTLESTICK],LowT,HighT,0,100);
-    ItoaPadded(CurThrottle,screenBuffer+2,3,0);
-    screenBuffer[5]='%';
+    ItoaPadded(CurThrottle,screenBuffer+1+THROTTLESPACE,3,0);
+    screenBuffer[4+THROTTLESPACE]='%';
   }
     screenBuffer[0]=SYM_THR;
-    screenBuffer[1]=' ';
-    screenBuffer[6]=0;
+    screenBuffer[5+THROTTLESPACE]=0;
     MAX7456_WriteString(screenBuffer,getPosition(CurrentThrottlePosition));
 }
 

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -433,8 +433,12 @@ void displayHorizon(int rollAngle, int pitchAngle)
       }
     }
 #endif
+    #ifdef USEGLIDESCOPE
+      if(Settings[S_DISPLAYGPS]){
+        displayfwglidescope();
+      }
+    #endif //USEGLIDESCOPE  
   }
-
 }
 
 
@@ -727,8 +731,17 @@ void displayNumberOfSat(void)
 {
 //  if(!GPS_fix)
 //    return;
-  if((GPS_numSat<MINSATFIX)&&(timer.Blink2hz))
+
+
+
+  if((GPS_numSat<MINSATFIX)&&(timer.Blink2hz)){
     return;
+  }
+  #ifdef DISP_LOW_SATS_WARNING
+    if (GPS_numSat<MINSATFIX){
+      MAX7456_WriteString_P(satlow_text, getPosition(motorArmedPosition));
+    }
+  #endif //DISP_LOW_SATS_WARNING
   if(!fieldIsVisible(GPS_numSatPosition))
     return;
   screenBuffer[0] = SYM_SAT_L;
@@ -1513,10 +1526,10 @@ for(uint8_t maptype=mapstart; maptype<mapend; maptype++) {
 void displayfwglidescope(void){
   int8_t GS_deviation_scale   = 0;
   if (GPS_distanceToHome>0){ //watch div 0!!
-    int16_t gs_angle          =(573*atan((float)MwAltitude/100/GPS_distanceToHome));
+    int16_t gs_angle          =(573*atan((float)MwAltitude/10/GPS_distanceToHome));
     int16_t GS_target_delta   = gs_angle-USEGLIDESCOPE;
-    GS_target_delta           = constrain(GS_target_delta,-40,40); 
-    GS_deviation_scale        = map(GS_target_delta,40,-40,0,8);
+    GS_target_delta           = constrain(GS_target_delta,-400,400); 
+    GS_deviation_scale        = map(GS_target_delta,400,-400,0,8);
   }
 
   int8_t varline              = (GS_deviation_scale/3)-1;


### PR DESCRIPTION
Added option in config.h to provide text warning if satfix is below
minimum required.
Improved function of feature which invokes after loss of sat data for xx
seconds.
Small teak to glidescope display - linked to sidebars so remains hidden
if sidebars not used in screen layout chosen