### PR TITLE
MSP serial speed choice introduction

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -5,6 +5,7 @@
 //Choose ONLY ONE option:
 #define MINIMOSD                    // Uncomment this if using standard MINIMOSD hardware (default for 95% of boards) 
 //#define WITESPYV1.1               // Uncomment this if using Witespy V1.1 OSD, select this to correct for both swapped bat1/bat 2 and to also use alternative resistors / pinouts.  
+//#define WITESPYMICRO              // Uncomment this if using Witespy Micro Minim OSD, select this to correct for swapped bat1/bat 2.  
 //#define RUSHDUINO                 // Uncomment this if using Rushduino
 
 // NOTE-some of the popular RTFQ/Witespy boards have swapped bat1/bat2 pins and alternative voltage measuring resistors
@@ -24,7 +25,7 @@
 //#define CLEANFLIGHT180            // Uncomment this if you are using CLEANFLIGHT versions up to and including 1.8.0
 //#define CLEANFLIGHT181            // Uncomment this if you are using CLEANFLIGHT versions 1.8.1 
 //#define HARIKIRI                  // Uncomment this if you are using HARIKIRI (for BOXNAMES compatibility)
-//#define GPSOSD_GPSOSD_UBLOX       // Uncomment this if you are using a UBLOX GPS module for a GPS based OSD
+//#define GPSOSD_UBLOX       // Uncomment this if you are using a UBLOX GPS module for a GPS based OSD
 //#define GPSOSD_NMEA               // Uncomment this if you are using a NMEA compatible GPS module for a GPS based OSD
 //#define GPSOSD_MTK                // Uncomment this if you are using a MTK module for a GPS based OSD
 //#define NOCONTROLLER              // Uncomment this if you ahave nothing connected to the serial port - no controller or GPS module
@@ -93,7 +94,7 @@
 
 
 /******************** Serial MSP speed settings *********************/
-// Choose ONLY ONE option: increases speeds of serial update - but with impact to fligth controller 
+// Choose ONLY ONE option: increases speeds of serial update - but with impact to flight controller 
 //#define MSP_SPEED_LOW
 #define MSP_SPEED_MED
 //#define MSP_SPEED_HIGH
@@ -108,7 +109,7 @@
 
 
 /********************       STARTUP settings      *********************/
-//#define INTRO_VERSION               "SHIKI-OSD - R1.4" // Call the OSD something else if you prefer. KVOSD is not permitted - LOL. 
+#define INTRO_VERSION               "MWOSD - DEV 1.4.2" // Call the OSD something else if you prefer. KVOSD is not permitted - LOL. 
 //#define INTRO_CALLSIGN            // Enable to display callsign at startup
 //#define INTRO_TIMEZONE            // Enable to display timezone at startup - if GPS TIME is enabled
 //#define INTRO_DELAY 5             // Seconds intro screen should show for. Default is 10 
@@ -173,7 +174,7 @@
 
 
 /*----------------------------------------------       Developer parameters      ----------------------------------------------------*/
-#define DEBUG         // Enable/disable option to display OSD debug values 
+//#define DEBUG         // Enable/disable option to display OSD debug values 
 //#define DEBUGMW       // Disable to prevent load Mutltiwii debug values from MSP 
 
 

--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -92,6 +92,13 @@
 //#define BAUDRATE 9600
 
 
+/******************** Serial MSP speed settings *********************/
+// Choose ONLY ONE option: increases speeds of serial update - but with impact to fligth controller 
+//#define MSP_SPEED_LOW
+#define MSP_SPEED_MED
+//#define MSP_SPEED_HIGH
+
+
 /********************       CALLSIGN settings      *********************/
 #define   CALLSIGNINTERVAL 60      // How frequently to display Callsign (in seconds)
 #define   CALLSIGNDURATION 4       // How long to display Callsign (in seconds)

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -83,6 +83,10 @@
     #define ALTERNATEDIVIDERS
 #endif
 
+#ifdef WITESPYMICRO                     
+    #define SWAPVOLTAGEPINS
+#endif
+
 #ifdef SWAPVOLTAGEPINS                     
     #define VOLTAGEPIN    A2
     #define VIDVOLTAGEPIN A0
@@ -150,6 +154,7 @@
   #undef  OSD_SWITCH_RC
   #define FORCESENSORS
   #define HIDEARMEDSTATUS
+  #define GPSACTIVECHECK 5  
 #endif
 
 #if defined MSP_SPEED_HIGH

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -152,5 +152,15 @@
   #define HIDEARMEDSTATUS
 #endif
 
+#if defined MSP_SPEED_HIGH
+  #define hi_speed_cycle  5
+#elif defined MSP_SPEED_MED
+  #define hi_speed_cycle  15
+#elif defined MSP_SPEED_MED
+  #define hi_speed_cycle  50
+#else
+  #define hi_speed_cycle  50
+#endif
+
 
 

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -19,7 +19,6 @@
 #define METRIC 0
 #define IMPERIAL 1
 
-#define hi_speed_cycle  50
 #define lo_speed_cycle  100
 
 #define CALIBRATION_DELAY 10       // Calibration timeouts   
@@ -116,6 +115,12 @@ struct {
   uint8_t GPS_active;
 }
 timer;
+
+struct {
+  uint8_t ident;
+  uint8_t box;
+}
+flags;
 
 uint16_t debug[4];   // int32_t ?...
 int8_t menudir;
@@ -872,10 +877,10 @@ uint16_t screenPosition[POSITIONS_SETTINGS];
 #define REQ_MSP_STATUS    (1 <<  1)
 #define REQ_MSP_RAW_IMU   (1 <<  2)
 #define REQ_MSP_RC        (1 <<  3)
-#define REQ_MSP_RAW_GPS   (1 <<  4)
+#define REQ_MSP_ALTITUDE  (1 <<  4)
 #define REQ_MSP_COMP_GPS  (1 <<  5)
 #define REQ_MSP_ATTITUDE  (1 <<  6)
-#define REQ_MSP_ALTITUDE  (1 <<  7)
+#define REQ_MSP_RAW_GPS   (1 <<  7)
 #define REQ_MSP_ANALOG    (1 <<  8)
 #define REQ_MSP_RC_TUNING (1 <<  9)
 #define REQ_MSP_PID       (1 << 10)

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -22,7 +22,7 @@ This work is based on the following open source work :-
 */
 
 //------------------------------------------------------------------------
-//#define MEMCHECK 3 // to enable memeory checking and set debug[x] value
+#define MEMCHECK 3 // to enable memeory checking and set debug[x] value
 #if 1
 __asm volatile ("nop");
 #endif
@@ -186,6 +186,8 @@ void loop()
     timer.halfSec++;
     timer.Blink10hz=!timer.Blink10hz;
     calculateTrip();
+    if (Settings[S_AMPER_HOUR]) 
+      amperagesum += amperage;
     #ifndef GPSOSD 
       #ifndef FASTMSP
         if(!fontMode)
@@ -307,7 +309,7 @@ void loop()
           displayRSSI();
         if(Settings[S_AMPERAGE]&&(((amperage/10)<Settings[S_AMPERAGE_ALARM])||(timer.Blink2hz))) 
           displayAmperage();
-        if(Settings[S_AMPER_HOUR]&&((((amperagesum)/3600)<Settings[S_AMPER_HOUR_ALARM])||(timer.Blink2hz)))
+        if(Settings[S_AMPER_HOUR]&&((((amperagesum)/36000)<Settings[S_AMPER_HOUR_ALARM])||(timer.Blink2hz)))
           displaypMeterSum();
         displayTime();
 #ifdef TEMPSENSOR
@@ -395,8 +397,6 @@ void loop()
         timer.MSP_active--;
       }      
     #endif // MSPACTIVECHECK 
-    if (Settings[S_AMPER_HOUR]) 
-      amperagesum += amperage;
 
     if(!armed) {
       setMspRequests();
@@ -582,9 +582,9 @@ void calculateTrip(void)
   static float tripSum = 0; 
   if(GPS_fix && armed && (GPS_speed>0)) {
     if(Settings[S_UNITSYSTEM])
-      tripSum += GPS_speed *0.0016404;     //  50/(100*1000)*3.2808=0.0016404     cm/sec ---> ft/50msec
+      tripSum += GPS_speed *0.0032808;     //  100/(100*1000)*3.2808=0.0016404     cm/sec ---> ft/50msec
     else
-      tripSum += GPS_speed *0.0005;        //  50/(100*1000)=0.0005               cm/sec ---> mt/50msec (trip var is float)      
+      tripSum += GPS_speed *0.0010;        //  100/(100*1000)=0.0005               cm/sec ---> mt/50msec (trip var is float)      
   }
   trip = (uint32_t) tripSum;
 }

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -1,7 +1,6 @@
 #define DATAOUT 11              // MOSI
 #define DATAIN  12              // MISO
 #define SPICLOCK  13            // sck
-
 #define VSYNC 2                 // INT0
 
 #ifndef WHITEBRIGHTNESS
@@ -263,7 +262,7 @@ void MAX7456_DrawScreen()
     spi_transfer(DMAL_reg);
     spi_transfer(0);
     vsync_wait = 1;
-    uint32_t vsynctimer=50+millis();
+    uint32_t vsynctimer=40+millis();
 
   #endif
 
@@ -273,7 +272,7 @@ void MAX7456_DrawScreen()
     #ifdef USE_VSYNC
       SPDR = MAX7456ADD_DMDI;
       if (xx==240) {
-        vsynctimer=50+millis();
+        vsynctimer=40+millis();
         vsync_wait = 1;      // Not enough time to load all characters within VBI period. This splits and waits until next field
       }
       while (!(SPSR & (1<<SPIF)));     // Wait the end of the last SPI transmission is clear
@@ -282,7 +281,7 @@ void MAX7456_DrawScreen()
           vsync_wait=0;
         }
         else{
-          serialMSPreceive(); // Might as well do something whilst waiting :)
+          serialMSPreceive(0); // Might as well do something whilst waiting :)
         }
       }
       SPDR = screen[xx];

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -554,7 +554,7 @@ void displaypMeterSum(void)
   if(!fieldIsVisible(pMeterSumPosition))
     return;
   screenBuffer[0]=SYM_MAH;
-  int xx=amperagesum/36;
+  int xx=amperagesum/360;
   itoa(xx,screenBuffer+1,10);
   MAX7456_WriteString(screenBuffer,getPosition(pMeterSumPosition));
 }
@@ -1041,7 +1041,7 @@ void displayConfigScreen(void)
  //   MAX7456_WriteString_P(configMsg04, ALTT);
     MAX7456_WriteString(itoa(speedMAX,screenBuffer,10),VELD-3);
 
-    xx=amperagesum/36;
+    xx=amperagesum/360;
     itoa(xx,screenBuffer,10);
 //    MAX7456_WriteString_P(configMsg06, VELT);
     MAX7456_WriteString(itoa(xx,screenBuffer,10),LEVD-3);

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -759,6 +759,7 @@ void serialMSPreceive(uint8_t loops)
         serialBuffer[receiverIndex++]=c;
     }
     if (loops==0) loopserial=0;
+    if (!Serial.available()) loopserial=0;
   }
 }
 


### PR DESCRIPTION
First implementation of option for faster serial speed updates.
Moved away from fixed timer dependant updates for MSP
Removed unnecessary update requests
Update requests linked to functionality available
Preset speed updates in config.h
Vsync update wait period utilisation migrated to single shot serial
available to remove screen update blocking / remove possible sparklies