### PR TITLE
Adding option in config.h when FC sends current data in multiples of 100mA

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -194,4 +194,8 @@
 //#define TEMPSENSOR                // Enable if you have a hardware temperature sensor - DEPRECATED
 #define TEMPERATUREMAX 50           // Temperature warning value
 
+/********************  FC CURRENT sensor units    *********************/
+#ifdef MULTIWII_V24                     
+//  #define AMPERAGE100MA         // unccoment if your FC sends current in "1unit = 100mA" units
+#endif
 

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -277,6 +277,11 @@ void serialMSPCheck()
 #ifdef AMPERAGECORRECT
     MWAmperage = MWAmperage * 10;
 #endif
+#ifdef AMPERAGE100MA
+    //MW_OSD.ino will 'amperage = MWAmperage / 100;' so premultiply values by 100
+    MWAmperage = MWAmperage * 100;
+#endif
+
  }
 
 #if defined (BASEFLIGHT20150627)  


### PR DESCRIPTION
My multiwii 2.4 sends current data in multiplies of 100mA so when it got divided by 100 I got 0 for lot of time. This way in config somebody with same issue can just uncomment the #define and then the division will get canceled out by pre-multiplication of 100. This way the used mAh work correctly as well.