### PR TITLE
Voltage configuration over MSP

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -209,6 +209,9 @@
 #define NAZA_MODE_ATI 
 #define NAZA_MODE_MAN 1400
 
+/********************       Baseflight / Cleanflight Settings         ************************/
+//#define FC_VOLTAGE_CONFIG            // Uncomment this if you are using the vbat voltage config (include: min cell voltage, max cell voltage and warning cell voltage) from the flight controller (only for Baseflight and Cleanflight)
+
 
 /********************       FrSky S.Port settings      *********************/
 //enables data transfer from frsky reciever s.port to osd via multiwii

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -84,6 +84,10 @@
   #define BOXNAMES                  // required to support legacy protocol
 #endif
 
+#if defined (FC_VOLTAGE_CONFIG) && (defined (CLEANFLIGHT) || defined(BASEFLIGHT))
+  #define USE_FC_VOLTS_CONFIG
+#endif
+
 /********************   ENABLE/DISABLE CONFIG PAGES via STICK MENU     *********************/
 //large memory savings if not needed, comment to disable
 #define PAGE1 //PID CONFIG

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -523,6 +523,10 @@ uint16_t pMeterSum=0;
 uint16_t MwRssi=0;
 uint32_t GPS_time = 0;        //local time of coord calc - haydent
 
+uint8_t MvVBatMinCellVoltage=0;
+uint8_t MvVBatMaxCellVoltage=0;
+uint8_t MvVBatWarningCellVoltage=0;
+
 // For decoration
 uint8_t SYM_AH_DECORATION_LEFT = 0x10;
 uint8_t SYM_AH_DECORATION_RIGHT = 0x10;
@@ -564,6 +568,7 @@ int16_t pwmRSSI = 0;
 // For Voltage
 uint16_t voltage=0;                      // its the value x10
 uint16_t vidvoltage=0;                   // its the value x10
+uint8_t voltageWarning=0;
 
 // For temprature
 int16_t temperature=0;                  // temperature in degrees Centigrade
@@ -905,6 +910,7 @@ uint16_t screenPosition[POSITIONS_SETTINGS];
 #define REQ_MSP_CELLS     (1 << 14)
 #define REQ_MSP_NAV_STATUS  32768 //(1 << 15)
 #define REQ_MSP_CONFIG  32768 //(1 << 15)
+#define REQ_MSP_MISC      65536 // (1 << 16)
 
 // Menu
 //PROGMEM const char *menu_stats_item[] =

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -455,10 +455,17 @@ void displayVoltage(void)
   }
 
   if (Settings[S_SHOWBATLEVELEVOLUTION]){
-
+#ifdef USE_FC_VOLTS_CONFIG
+    uint8_t cells = (voltage / MvVBatMaxCellVoltage) + 1;
+    int battev = voltage/(int)cells;
+    battev = constrain(battev, MvVBatMinCellVoltage, MvVBatMaxCellVoltage);
+    battev = map(battev, MvVBatMinCellVoltage, MvVBatMaxCellVoltage, 0, 6);
+#else
     int battev=voltage/Settings[S_BATCELLS];
     battev=constrain(battev,34,42);
     battev = map(battev, 34, 42, 0, 6);
+#endif //USE_FC_VOLTS_CONFIG
+
     screenBuffer[0]=SYM_BATT_EMPTY-battev;
   }
   else {
@@ -466,12 +473,12 @@ void displayVoltage(void)
   }
 
 #ifdef DISP_LOW_VOLTS_WARNING
-  if (voltage<=Settings[S_VOLTAGEMIN]&&!armedtimer)
+  if (voltage<=voltageWarning&&!armedtimer)
     MAX7456_WriteString_P(lowvolts_text, getPosition(motorArmedPosition));
 #endif
 
 #ifdef FORCE_DISP_LOW_VOLTS
-  if(fieldIsVisible(voltagePosition)||(voltage<=Settings[S_VOLTAGEMIN])) 
+  if(fieldIsVisible(voltagePosition)||(voltage<=voltageWarning)) 
 #else
   if(fieldIsVisible(voltagePosition)) 
 #endif

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -266,6 +266,35 @@ void serialMSPCheck()
     MWAmperage = read16();
  }
 
+#ifdef USE_FC_VOLTS_CONFIG
+  if (cmdMSP==MSP_MISC)
+  {
+    read16(); //ignore: midrc
+
+    read16(); //ignore: minthrottle
+    read16(); //ignore: maxthrottle
+    read16(); //ignore: mincommand
+
+    read16(); //ignore: failsafe_throttle
+    
+    read8(); //ignore: gps_type
+    read8(); //ignore: gps_baudrate
+    read8(); //ignore: gps_ubx_sbas
+
+    read8(); //ignore: multiwiiCurrentMeterOutput
+    read8(); //ignore: rssi_channel
+    read8(); //ignore: 0
+
+    read16(); //ignore: mag_declination
+
+    read8(); //ignore: vbatscale
+    MvVBatMinCellVoltage = read8(); //vbatmincellvoltage
+    MvVBatMaxCellVoltage = read8(); //vbatmaxcellvoltage
+    MvVBatWarningCellVoltage = read8(); //vbatwarningcellvoltage
+    
+  }
+#endif //USE_FC_VOLTS_CONFIG
+
 #if defined (BASEFLIGHT20150627)  
   if (cmdMSP==MSP_CONFIG)
   {


### PR DESCRIPTION
Hello
This PR allows to read the voltage configuration from the FC (cleanflight and baseflight) over MSP.
Included: min cell voltage, max cell voltage and warning cell voltage.

Very helpful when you use multiple lipo configuration e.g. S3 and S4 or lipo and LiFePo.

The voltage warning is now calculated with the "warning cell voltage". The number of cells is not irrelevant.
```c
uint8_t cells = (voltage / MvVBatMaxCellVoltage) + 1;
voltageWarning = cells * MvVBatWarningCellVoltage;
```
