### PR TITLE
Remove requests for MSP_RAW_IMU

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -481,7 +481,6 @@ static uint8_t thrExpo8;
 static uint16_t tpa_breakpoint16;
 static uint8_t rcYawExpo8;
 
-static uint16_t  MwAccSmooth[3]={0,0,0};       // Those will hold Accelerator data
 int32_t  MwAltitude=0;                         // This hold barometric value
 int32_t  old_MwAltitude=0;                     // This hold barometric value
 

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -291,9 +291,6 @@ void loop()
       case REQ_MSP_STATUS:
         MSPcmdsend = MSP_STATUS;
         break;
-      case REQ_MSP_RAW_IMU:
-        MSPcmdsend = MSP_RAW_IMU;
-        break;
       case REQ_MSP_RC:
         MSPcmdsend = MSP_RC;
         break;
@@ -616,7 +613,6 @@ void setMspRequests() {
       REQ_MSP_STATUS|
       REQ_MSP_RAW_GPS|
       REQ_MSP_ATTITUDE|
-      REQ_MSP_RAW_IMU|
       REQ_MSP_ALTITUDE|
       REQ_MSP_RC_TUNING|
       REQ_MSP_PID|
@@ -648,9 +644,6 @@ void setMspRequests() {
       REQ_MSP_CELLS|
      #endif
       REQ_MSP_ATTITUDE;
-    if(MwSensorPresent&MAGNETOMETER){ 
-      modeMSPRequests |= REQ_MSP_RAW_IMU;
-    }
     if(MwSensorPresent&BAROMETER){ 
       modeMSPRequests |= REQ_MSP_ALTITUDE;
     }

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -156,12 +156,6 @@ void serialMSPCheck()
 
   }
 
-  if (cmdMSP==MSP_RAW_IMU)
-  {
-    for(uint8_t i=0;i<3;i++)
-      MwAccSmooth[i] = read16();
-  }
-
   if (cmdMSP==MSP_RC)
   {
     for(uint8_t i=0;i<8;i++)


### PR DESCRIPTION
MSP_RAW_IMU is requested when the mag is enabled.

The response to this is processed thusly:

```
  if (cmdMSP==MSP_RAW_IMU)
  {
    for(uint8_t i=0;i<3;i++)
      MwAccSmooth[i] = read16();
  }
```

But MwAccSmooth is never used.  This is a global variable, some code, and some time on the serial port to process data that's not used.

I noticed this while bringing up MWOSD on a new type of flight control platform.  Ignoring it doesn't break anything, but not requesting it is even better.