### PR TITLE
Mah Batt Evolution Icon option, map() function fixes for even icon distribution across range

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -165,7 +165,7 @@
 #define MAPMODE         // Enable/disable MAP MODE - map indication of relative positions of home and aircraft
 //#define GPSTIME       // Enable/disable GPS Time functions
 //#define SPORT         // Enable/disable FRSKY S.PORT cell code
-
+//#define BATICON4AMHR    //Enable using 'Show Bat Status' icon as percentage of AMPHR alarm limit instead of by cell voltage...warning will now be at 80% of that GUI value
 
 /********************       Display Settings         ************************/
 #define MAXSTALLDETECT              // Enable to attempt to detect MAX chip stall from bad power. Attempts to restart.

--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -165,7 +165,7 @@
 #define MAPMODE         // Enable/disable MAP MODE - map indication of relative positions of home and aircraft
 //#define GPSTIME       // Enable/disable GPS Time functions
 //#define SPORT         // Enable/disable FRSKY S.PORT cell code
-//#define BATICON4AMHR    //Enable using 'Show Bat Status' icon as percentage of AMPHR alarm limit instead of by cell voltage...warning will now be at 80% of that GUI value
+//#define BATICON4AMPHR    //Enable using 'Show Bat Status' icon as percentage of AMPHR alarm limit instead of by cell voltage...warning will now be at 80% of that GUI value
 
 /********************       Display Settings         ************************/
 #define MAXSTALLDETECT              // Enable to attempt to detect MAX chip stall from bad power. Attempts to restart.

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -894,7 +894,7 @@ void ProcessSensors(void) {
 
 #ifdef AUTOVOLTWARNING
   uint8_t cells = ((voltage-3) / MvVBatMaxCellVoltage) + 1;
-  voltageWarning = cells * MvVBatWarningCellVoltage;
+  voltageWarning = cells * (Settings[S_VOLTAGEMIN]/Settings[S_BATCELLS]);
 #else
   voltageWarning = Settings[S_VOLTAGEMIN];
 #endif  

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -480,16 +480,17 @@ void displayVoltage(void)
 //    voltage=MwVBat;
   }
 
-  if (Settings[S_SHOWBATLEVELEVOLUTION]){
+   if (Settings[S_SHOWBATLEVELEVOLUTION] &&  !Settings[S_AMPER_HOUR]){
 #ifdef AUTOVOLTWARNING
     uint8_t cells = ((voltage-3) / MvVBatMaxCellVoltage) + 1;
     int battev = voltage/(int)cells;
+    MvVBatMinCellVoltage=cells*Settings[S_VOLTAGEMIN]/Settings[S_BATCELLS];
     battev = constrain(battev, MvVBatMinCellVoltage, MvVBatMaxCellVoltage);
-    battev = map(battev, MvVBatMinCellVoltage, MvVBatMaxCellVoltage, 0, 6);
+    battev = map(battev, MvVBatMinCellVoltage, MvVBatMaxCellVoltage+1, 0, 7);
 #else
     int battev=voltage/Settings[S_BATCELLS];
-    battev=constrain(battev,34,42);
-    battev = map(battev, 34, 42, 0, 6);
+    battev=constrain(battev,33,40);
+    battev = map(battev, 33, 41, 0, 7);
 #endif //USE_FC_VOLTS_CONFIG
 
     screenBuffer[0]=SYM_BATT_EMPTY-battev;
@@ -634,9 +635,22 @@ void displaypMeterSum(void)
 {
   if(!fieldIsVisible(pMeterSumPosition))
     return;
+#ifdef BATICON4AMPHR
+    if (Settings[S_SHOWBATLEVELEVOLUTION]){
+    battev=amperagesum/(360*Settings[S_AMPER_HOUR_ALARM]);
+    battev=constrain(battev,0,100);
+    battev = map(100-battev, 0, 101, 0, 7);
+    screenBuffer[0]=SYM_BATT_EMPTY-battev;
+    screenBuffer[1]=SYM_MAH;
+    int xx=amperagesum/360;
+    itoa(xx,screenBuffer+2,10);
+  }else 
+  #endif
+  {
   screenBuffer[0]=SYM_MAH;
   int xx=amperagesum/360;
   itoa(xx,screenBuffer+1,10);
+  }
   MAX7456_WriteString(screenBuffer,getPosition(pMeterSumPosition));
 }
 

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -480,7 +480,12 @@ void displayVoltage(void)
 //    voltage=MwVBat;
   }
 
-   if (Settings[S_SHOWBATLEVELEVOLUTION] &&  !Settings[S_AMPER_HOUR]){
+#ifdef BATICON4AMPHR
+  if (Settings[S_SHOWBATLEVELEVOLUTION] &&  !Settings[S_AMPER_HOUR] )
+#else
+  if (Settings[S_SHOWBATLEVELEVOLUTION])
+#endif
+{
 #ifdef AUTOVOLTWARNING
     uint8_t cells = ((voltage-3) / MvVBatMaxCellVoltage) + 1;
     int battev = voltage/(int)cells;


### PR DESCRIPTION
Added ability to have evolution icon based on mah used;alarm level value in GUI is now batt capacity;alarm at 80% of that value
Allowed min main bat cell volatge to be input on gui even in autodetect rather than by compile option
Fixed useage of map() function
