### PR TITLE
Accuracy updates for current.

### DIFF
--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -50,37 +50,41 @@
   #define BOXNAMES                  // required to support legacy protocol
 #endif
 
-#if defined (BASEFLIGHT20150327)            
-  #define AMPERAGE_10ma
+// The unit of current varies across implementations.  There are effectively three set:
+// * 100mA, for which case the value is usable as it comes aross the wire.
+// * 10mA, which sends a value 10x higher than we work wth
+// * 1ma, which sends a value 100x higher than normal
+#define AMPERAGE_DIV 100
+
+#if defined (BASEFLIGHT20150327)
+  #define AMPERAGE_DIV 10
 #endif
 
 #if defined (BASEFLIGHT20150627)
-  #define AMPERAGE_10ma
+  #define AMPERAGE_DIV 10
   #define SETCONFIG 25                  //for BASEFLIGHT20150627 to use MSP_SET_CONFIG
 #endif
 
-#if defined (CLEANFLIGHT190)         
-  #define AMPERAGE_10ma
+#if defined (CLEANFLIGHT190)
+  #define AMPERAGE_DIV 10
 #endif
 
 #if defined (CLEANFLIGHT180)
-  #define AMPERAGE_10ma
+  #define AMPERAGE_DIV 10
 #endif
 
 #if defined (CLEANFLIGHT172)
-  #define AMPERAGE_10ma
+  #define AMPERAGE_DIV 10
 #endif
 
-#if defined (MULTIWII_V24)                
-  #define AMPERAGE_100ma
+#if defined (MULTIWII_V24)
+  #define AMPERAGE_DIV 1
 #endif
 
-#if defined (MULTIWII_V23)                
-  #define AMPERAGE_1ma
+#if defined (MULTIWII_V23)
 #endif
 
-#if defined (MULTIWII_V21)                
-  #define AMPERAGE_1ma         
+#if defined (MULTIWII_V21)
   #define BOXNAMES                  // required to support legacy protocol
 #endif
 

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -933,16 +933,7 @@ void ProcessSensors(void) {
     }  
   }
   else{
-#if defined AMPERAGE_100ma
-      amperage = MWAmperage ;
-#elif defined AMPERAGE_10ma
-      amperage = MWAmperage / 10;
-#elif defined AMPERAGE_1ma
-      amperage = MWAmperage / 100;
-#else
-      amperage = MWAmperage / 100;
-#endif
-
+    amperage = MWAmperage / AMPERAGE_DIV;
   }
 
 //-------------- RSSI

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -186,6 +186,14 @@ void loop()
 }
 #else
 
+// ampAlarming returns true if the total consumed mAh is greater than
+// the configured alarm value (which is stored as 100s of amps)
+static bool ampAlarming() {
+    int used = pMeterSum > 0 ? pMeterSum : (amperagesum / 360);
+    return used > (Settings[S_AMPER_HOUR_ALARM]*100);
+}
+
+
 //------------------------------------------------------------------------
 void loop()
 {
@@ -407,7 +415,7 @@ void loop()
           displayRSSI();
         if(Settings[S_AMPERAGE]&&(((amperage/10)<Settings[S_AMPERAGE_ALARM])||(timer.Blink2hz))) 
           displayAmperage();
-        if(Settings[S_AMPER_HOUR]&&((((amperagesum)/36000)<Settings[S_AMPER_HOUR_ALARM])||(timer.Blink2hz)))
+        if(Settings[S_AMPER_HOUR] && ((!ampAlarming()) || timer.Blink2hz))
           displaypMeterSum();
         displayTime();
 #ifdef TEMPSENSOR

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -635,7 +635,7 @@ void displaypMeterSum(void)
   if(!fieldIsVisible(pMeterSumPosition))
     return;
   screenBuffer[0]=SYM_MAH;
-  int xx=amperagesum/360;
+  int xx = pMeterSum > 0 ? pMeterSum : amperagesum/360;
   itoa(xx,screenBuffer+1,10);
   MAX7456_WriteString(screenBuffer,getPosition(pMeterSumPosition));
 }


### PR DESCRIPTION
baseflight, cleanflight and Tau Labs (at least) send accumulated current in the analog result.  MWOSD picks this up, but ignores it, although it's likely to be far more accurate than having MWOSD attempt to compute it from the instantaneous current samples it's picking up.

This code just uses the `pMeterSum` value itself if available, else falls back on `amperagesum`, which should work in the case where accumulated current isn't sent along with the analog values.