### PR TITLE
Adding support for a generic alarming system

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -35,6 +35,7 @@
 // latest release...
 #define MULTIWII                  // Uncomment this if you are using latest MULTIWII version from repository (2.4 at time of this MWOSD release)
 //#define BASEFLIGHT                // Uncomment this if you are using latest BASEFLIGHT version from repository (Stable 2015.06.27 at time of this MWOSD release)
+//#define TAULABS                   // Uncomment this if you are using the latest Tau Labs MSP Module
 //#define CLEANFLIGHT               // Uncomment this if you are using latest CLEANFLIGHT version from repository (1.9.0 at time or this MWOSD release)
 //#define HARIKIRI                  // Uncomment this if you are using HARIKIRI (for BOXNAMES compatibility)
 //#define NAZA                      // Uncomment this if you are using NAZA flight controller

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -88,6 +88,15 @@
   #define USE_FC_VOLTS_CONFIG
 #endif
 
+#if defined(TAULABS)
+  #define AMPERAGE_DIV 10
+  #define HAS_ALARMS
+#endif
+
+#ifdef HAS_ALARMS
+  #define MAX_ALARM_LEN 30
+#endif
+
 /********************   ENABLE/DISABLE CONFIG PAGES via STICK MENU     *********************/
 //large memory savings if not needed, comment to disable
 #define PAGE1 //PID CONFIG

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -523,6 +523,16 @@ uint16_t pMeterSum=0;
 uint16_t MwRssi=0;
 uint32_t GPS_time = 0;        //local time of coord calc - haydent
 
+#ifdef HAS_ALARMS
+#define ALARM_OK 0
+#define ALARM_WARN 1
+#define ALARM_ERROR 2
+#define ALARM_CRIT 3
+
+uint8_t alarmState = ALARM_OK;
+uint8_t alarmMsg[MAX_ALARM_LEN];
+#endif
+
 uint8_t MvVBatMinCellVoltage=CELL_VOLTS_MIN;
 uint8_t MvVBatMaxCellVoltage=CELL_VOLTS_MAX;
 uint8_t MvVBatWarningCellVoltage=CELL_VOLTS_WARN;
@@ -644,6 +654,8 @@ uint16_t flyingTime=0;
 #define MSP_SET_HEAD             211   //in message          define a new heading hold direction
 
 #define MSP_BIND                 240   //in message          no param
+
+#define MSP_ALARMS               242   //in message          poll for alert text
 
 #define MSP_EEPROM_WRITE         250   //in message          no param
 
@@ -911,6 +923,7 @@ uint16_t screenPosition[POSITIONS_SETTINGS];
 #define REQ_MSP_NAV_STATUS  32768 //(1 << 15)
 #define REQ_MSP_CONFIG  32768 //(1 << 15)
 #define REQ_MSP_MISC      65536 // (1 << 16)
+#define REQ_MSP_ALARMS    131072 // (1 << 17)
 
 // Menu
 //PROGMEM const char *menu_stats_item[] =

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -351,6 +351,11 @@ void loop()
          MSPcmdsend = MSP_CONFIG;
       break;
 #endif
+#ifdef HAS_ALARMS
+      case REQ_MSP_ALARMS:
+          MSPcmdsend = MSP_ALARMS;
+      break;
+#endif
     }
     
     if(!fontMode){
@@ -465,6 +470,9 @@ void loop()
 #ifdef SPORT        
         if(MwSensorPresent)
           displayCells();
+#endif
+#ifdef HAS_ALARMS
+        displayAlarms();
 #endif
       }
     }
@@ -645,6 +653,9 @@ void setMspRequests() {
      #endif
      #ifdef SPORT      
       REQ_MSP_CELLS|
+     #endif
+     #ifdef HAS_ALARMS
+      REQ_MSP_ALARMS|
      #endif
       REQ_MSP_ATTITUDE;
     if(MwSensorPresent&BAROMETER){ 

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1664,6 +1664,13 @@ void displayArmed(void)
     return;  
   uint8_t message_no = 0;
 
+#ifdef HAS_ALARMS
+  if (alarmState != ALARM_OK) {
+      // There's an alarm, let it have this space.
+      return;
+  }
+#endif
+
   if(!armed){
     message_no=1;
     armedtimer=30;
@@ -1727,3 +1734,15 @@ void displayForcedCrosshair(){
   screen[position+2*LINE+7+1] = SYM_AH_CENTER_LINE_RIGHT;
   screen[position+2*LINE+7] =   SYM_AH_CENTER;
 }
+
+
+#ifdef HAS_ALARMS
+void displayAlarms() {
+    if (alarmState == ALARM_OK) {
+        return;
+    }
+    if (alarmState == ALARM_CRIT || alarmState == ALARM_ERROR || timer.Blink2hz) {
+        MAX7456_WriteString((const char*)alarmMsg, getPosition(motorArmedPosition));
+    }
+}
+#endif

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -351,6 +351,17 @@ void serialMSPCheck()
 
   }
 
+#ifdef HAS_ALARMS
+  if (cmdMSP == MSP_ALARMS)
+  {
+      alarmState = read8();
+      alarmMsg[min(dataSize-1, MAX_ALARM_LEN-1)] = 0;
+      for(uint8_t i = 0; i < dataSize-1; i++) {
+          alarmMsg[min(i, MAX_ALARM_LEN-1)] = read8();
+      }
+  }
+#endif /* HAS_ALARMS */
+
 #ifdef BOXNAMES
   if(cmdMSP==MSP_BOXNAMES) {
     flags.box=1;


### PR DESCRIPTION
As related to #129, there are many types of alarms the flight controller
may wish to report that aren't necessarily understood by all MWOSD.
This change allows for more flexible alarm reporting.