### PR TITLE
Implemented detection of air mode activation (requires Betaflight 2.1…

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -33,10 +33,10 @@
 // Choose ONLY ONE option from the following long list :-
 
 // latest release...
-#define MULTIWII                  // Uncomment this if you are using latest MULTIWII version from repository (2.4 at time of this MWOSD release)
+//#define MULTIWII                  // Uncomment this if you are using latest MULTIWII version from repository (2.4 at time of this MWOSD release)
 //#define BASEFLIGHT                // Uncomment this if you are using latest BASEFLIGHT version from repository (Stable 2015.06.27 at time of this MWOSD release)
 //#define TAULABS                   // Uncomment this if you are using the latest Tau Labs MSP Module
-//#define CLEANFLIGHT               // Uncomment this if you are using latest CLEANFLIGHT version from repository (1.9.0 at time or this MWOSD release)
+#define CLEANFLIGHT               // Uncomment this if you are using latest CLEANFLIGHT version from repository (1.9.0 at time or this MWOSD release)
 //#define HARIKIRI                  // Uncomment this if you are using HARIKIRI (for BOXNAMES compatibility)
 //#define NAZA                      // Uncomment this if you are using NAZA flight controller
 //#define GPSOSD_UBLOX              // Uncomment this if you are using a UBLOX GPS module for a GPS based OSD
@@ -174,12 +174,12 @@
 //#define ALT_CENTER                // Enable alternative center crosshair
 //#define FORCECROSSHAIR            // Forces a crosshair even if no AHI / horizon used
 //#define HIDEARMEDSTATUS           // Enable to hide ARMED / DISARMED status
-//#define FASTPIXEL                 // Optional - may improve resolution - especially hi res cams
+#define FASTPIXEL                 // Optional - may improve resolution - especially hi res cams
 //#define WHITEBRIGHTNESS 0x00      // Optional change from default 0x00=120%,0x01=100%,0x10=90%,0x11=80%  default is 0x01=100%
 //#define BLACKBRIGHTNESS 0x00      // Optional change from default 0x00=0%,0x01=10%,0x10=20%0x11=30%  default is 0x00=0%
 //#define FULLAHI                   // Enable to display a slightly longer AHI line
 //#define I2CERROR 3                // Autodisplay Mutltiwii I2C errors if exceeds specified count 
-//#define SHORTSTATS                // Display only timer on flight summary 
+#define SHORTSTATS                // Display only timer on flight summary 
 //#define NOTHROTTLESPACE           // Enable to remove space between throttle symbol and the data
 //#define REVERSEAHI                // Reverse pitch / roll direction of AHI - for DJI / Eastern bloc OSD users
 //#define DISPLAY_PR                // Display pitch / roll angles. Requires relevant layout ppositions to be enabled
@@ -213,8 +213,8 @@
 
 
 /********************       Voltage Warning Settings         ************************/
-//#define AUTOVOLTWARNING           // Uncomment this to use automatic voltage warning. Overrides GUI/OSD voltage warrning setting. Usefull if using different cell count batteries.
-//#define FC_VOLTAGE_CONFIG         // Additionally uncomment this if you want to use the vbat voltage config with BASEFLIGHT and CLEANFLIGHT on the flight controller (include: min cell voltage, max cell voltage and warning cell voltage)
+#define AUTOVOLTWARNING           // Uncomment this to use automatic voltage warning. Overrides GUI/OSD voltage warrning setting. Usefull if using different cell count batteries.
+#define FC_VOLTAGE_CONFIG         // Additionally uncomment this if you want to use the vbat voltage config with BASEFLIGHT and CLEANFLIGHT on the flight controller (include: min cell voltage, max cell voltage and warning cell voltage)
 //#define AUTOVOLTCELLALARM         // Overide Main battery Alarm value. Use individual cell value instead of default of total. i.e. 3.4 = 10.2v on a 3s
 //The following variables are available for adjustment unless using FC_VOLTAGE_CONFIG 
 #define CELL_VOLTS_WARN 35          // Specify the cell voltage level at which low voltage warning takes place eg. 35 = 3.5 volts per cell

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -166,6 +166,7 @@ struct {
   uint32_t llights;
   uint32_t gpsmission;
   uint32_t gpsland;
+  uint32_t air;
 }mode;
 
 // Settings Locations

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -190,75 +190,83 @@ void displayMode(void)
     screenBuffer[xx++] =SYM_M;
   else
    screenBuffer[xx++] =SYM_FT;
+   
    screenBuffer[xx++] =0;
  
-    if(MwSensorActive&mode.gpshome){
-      screenBuffer[0] = SYM_GHOME;
-      screenBuffer[1] = SYM_GHOME1;
+  if(MwSensorActive&mode.gpshome){
+    screenBuffer[0] = SYM_GHOME;
+    screenBuffer[1] = SYM_GHOME1;
 #ifdef APINDICATOR
-      screenBuffer[2]=0;
+    screenBuffer[2]=0;
 #else
-      screenBuffer[2] = SYM_COLON;
-      screenBuffer[8]=0;
+    screenBuffer[2] = SYM_COLON;
+    screenBuffer[8]=0;
 #endif
-    }
-    else if(MwSensorActive&mode.gpshold){
-      screenBuffer[2]=0;
-      screenBuffer[0] = SYM_GHOLD;
-      screenBuffer[1] = SYM_GHOLD1;
-    }
+  }
+  else if(MwSensorActive&mode.gpshold){
+    screenBuffer[2]=0;
+    screenBuffer[0] = SYM_GHOLD;
+    screenBuffer[1] = SYM_GHOLD1;
+  }
 #if defined MULTIWII_V24
-    else if(MwSensorActive&mode.gpsmission){
-      itoa(GPS_waypoint_step,screenBuffer+2,10);
-      screenBuffer[4]=0;
-      screenBuffer[0] = SYM_GMISSION;
-      screenBuffer[1] = SYM_GMISSION1;
-    }
-    else if(MwSensorActive&mode.gpsland){
-      screenBuffer[2]=0;
-      screenBuffer[0] = SYM_GLAND;
-      screenBuffer[1] = SYM_GLAND1;
-    }
+  else if(MwSensorActive&mode.gpsmission){
+    itoa(GPS_waypoint_step,screenBuffer+2,10);
+    screenBuffer[4]=0;
+    screenBuffer[0] = SYM_GMISSION;
+    screenBuffer[1] = SYM_GMISSION1;  
+  }
+  else if(MwSensorActive&mode.gpsland){
+    screenBuffer[2]=0;
+    screenBuffer[0] = SYM_GLAND;
+    screenBuffer[1] = SYM_GLAND1;
+  }
 #endif //MULTIWII_V24
     
-    else if(MwSensorActive&mode.stable){
-      screenBuffer[2]=0;
-      screenBuffer[0]=SYM_STABLE;
-      screenBuffer[1]=SYM_STABLE1;
-    }
-    else if(MwSensorActive&mode.horizon){
-      screenBuffer[2]=0;
-      screenBuffer[0]=SYM_HORIZON;
-      screenBuffer[1]=SYM_HORIZON1;
-    }
-    else if(MwSensorActive&mode.passthru){
-      screenBuffer[2]=0;
-      screenBuffer[0]=SYM_PASS;
-      screenBuffer[1]=SYM_PASS1;
-    }
-   else{
-      screenBuffer[2]=0;
-      #ifdef FIXEDWING
-        screenBuffer[0]=SYM_ACROGY;
-      #else
-        screenBuffer[0]=SYM_ACRO;
-      #endif
-      screenBuffer[1]=SYM_ACRO1;
-    }
+  else if(MwSensorActive&mode.stable){
+    screenBuffer[2]=0;
+    screenBuffer[0]=SYM_STABLE;
+    screenBuffer[1]=SYM_STABLE1;
+  }
+  else if(MwSensorActive&mode.horizon){
+    screenBuffer[2]=0;
+    screenBuffer[0]=SYM_HORIZON;
+    screenBuffer[1]=SYM_HORIZON1;
+  }
+  else if(MwSensorActive&mode.passthru){
+    screenBuffer[2]=0;
+    screenBuffer[0]=SYM_PASS;
+    screenBuffer[1]=SYM_PASS1;
+  }
+  else{
+    screenBuffer[2]=0;
+    #ifdef FIXEDWING
+      screenBuffer[0]=SYM_ACROGY;
+    #else
+      screenBuffer[0]=SYM_ACRO;
+    #endif
+    screenBuffer[1]=SYM_ACRO1;
+  }
+
+  // Display AIR MODE, append after flight mode
+  if(MwSensorActive&mode.air){
+    screenBuffer[2]=SYM_AIR;
+    screenBuffer[3]=SYM_AIR1;
+  }
+  
 #ifdef APINDICATOR
-      displayAPstatus();
+  displayAPstatus();
 #endif
-    if(Settings[S_MODEICON]){
+  if(Settings[S_MODEICON]){
     if(fieldIsVisible(ModePosition))
       MAX7456_WriteString(screenBuffer,getPosition(ModePosition));
-    }
-    if((MwSensorActive&mode.camstab)&&Settings[S_GIMBAL]){
-      screenBuffer[2]=0;
-      screenBuffer[0]=SYM_GIMBAL;
-      screenBuffer[1]=SYM_GIMBAL1;  
+  }
+  if((MwSensorActive&mode.camstab)&&Settings[S_GIMBAL]){
+    screenBuffer[2]=0;
+    screenBuffer[0]=SYM_GIMBAL;
+    screenBuffer[1]=SYM_GIMBAL1;  
     if(fieldIsVisible(gimbalPosition))
       MAX7456_WriteString(screenBuffer,getPosition(gimbalPosition));
-    }
+  }
 
   if(Settings[S_MODESENSOR]){
     xx = 0;

--- a/MW_OSD/symbols.h
+++ b/MW_OSD/symbols.h
@@ -179,6 +179,8 @@
 #define SYM_HORIZON1 0XC5
 #define SYM_PASS 0XAA
 #define SYM_PASS1 0XAB
+#define SYM_AIR 0XEA
+#define SYM_AIR1 0XEB
 
 // Time
 #define SYM_ON_M 0X9B


### PR DESCRIPTION
Implemented detection of air mode activation in Betaflight (requires Betaflight 2.1.5 or higher).

From Boris' Betaflight thread:

**Air mode**
* Enable Air mode on switch. I personally would prefer to use it together or next to an arming switch to always get full control at 0 throttle or separate switch so you can switch between normal and Air mode. When you use stick arming you will loose ability to yaw with 0 throttle, which might be a big miss. I was a stick armer before and really had to use myself to use switch to arm with air mode, but it was worth switching! All inverted and 0 stuff is much more fun now and disarming can be done quickly.
Of course you can stick with stick arming, but realize that there is now yaw with 0 throttle so you are missing a bit of fun. 
* Motor stop disables ability to use 0 throttle as the motors would stop. So you have to ask yourself if it is not worth of switching it off so you can enjoy the full fun

Link to thread: http://www.rcgroups.com/forums/showthread.php?t=2464844

Here is some visual demonstration of how to use air mode and enjoy more in air: https://youtu.be/b0qVUa4AeDQ