### PR TITLE
Acro+ isn't a betaflight specific thing

### DIFF
--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -275,11 +275,9 @@ void displayMode(void)
       screenBuffer[0]=SYM_ACRO;
     #endif
     screenBuffer[1]=SYM_ACRO1;
-//#if defined BETAFLIGHT
     if((MwSensorActive)&(mode.acroplus)){
       screenBuffer[1]=SYM_PLUS;
     }
-//#endif //BETAFLIGHT
   }
   if(Settings[S_MODEICON]){
     if(fieldIsVisible(ModePosition)){

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -510,11 +510,9 @@ void serialMSPCheck()
       case 28:
         mode.air |= bit;
         break;
-#if defined BETAFLIGHT
       case 29:
         mode.acroplus |= bit;
         break;
-#endif //BETAFLIGHT        
       }
       bit <<= 1;
       --remaining;


### PR DESCRIPTION
There are a few other firmwares that have had a mode called "Acro Plus"
for a while.  Let's support them all.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shikofthera/scarab-osd/189)
<!-- Reviewable:end -->
