### PR TITLE
Renamed menu identifiers to use names.

### DIFF
--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -61,18 +61,18 @@
   #define CORRECT_MENU_RCT2
   #define ENABLE_MSP_SAVE_ADVANCED
 
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU10  
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+  #define MENU_PROFILE  9       //PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_PROFILE
 #endif
 
 #if defined CLEANFLIGHT190
@@ -81,18 +81,18 @@
   #define CORRECT_MENU_RCT2
   #define ENABLE_MSP_SAVE_ADVANCED
 
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU10  
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+  #define MENU_PROFILE  9       //PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_PROFILE
   #define CORRECTLOOPTIME
 #endif
 
@@ -101,134 +101,134 @@
   #define CORRECT_MSP_CF1
   #define CORRECT_MENU_RCT1
 
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
 #if defined CLEANFLIGHT172
-  #define AMPERAGE_DIV 10
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define AMPERAGE_DIV  10
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
 #if defined BASEFLIGHT20150627
   #define AMPERAGE_DIV 10
   #define CORRECT_MSP_BF1
-  #define CORRECT_MENU_RCT1
+                       #define CORRECT_MENU_RCT1
   #define ENABLE_MSP_SAVE_ADVANCED
 
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU10   
-#endif  
+ #define MENU_STAT  0           //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+  #define MENU_PROFILE  9       //PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_PROFILE
+#endif
 
 #if defined (BASEFLIGHT20150327)
-  #define AMPERAGE_DIV 10
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define AMPERAGE_DIV  10
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE MENU_ALARMS
 #endif
 
 #if defined (MULTIWII_V24)
-  #define AMPERAGE_DIV 1
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-  #define MENU8  8 //GPS TIME
-  #define MENU9  9 //ALARMS
-//  #define MENU10 10//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define AMPERAGE_DIV  1
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+  #define MENU_GPS_TIME 8       //GPS TIME
+  #define MENU_ALARMS   9 //ALARMS
+//  #define MENU_PROFILE 10//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
 #if defined (MULTIWII_V23)
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
 #if defined (MULTIWII_V21)
-  #define BOXNAMES                  // required to support legacy protocol
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define BOXNAMES              // required to support legacy protocol
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6 //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
 #if defined(TAULABS)
-  #define AMPERAGE_DIV 10
+  #define AMPERAGE_DIV  10
   #define HAS_ALARMS
-  #define MENU0  0 //STATISTICS
-  #define MENU1  1 //PID CONFIG
-  #define MENU2  2 //RC TUNING
-  #define MENU3  3 //VOLTAGE
-  #define MENU4  4 //RSSI
-  #define MENU5  5 //CURRENT
-  #define MENU6  6 //DISPLAY
-  #define MENU7  7 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  8 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define MENU_STAT     0       //STATISTICS
+  #define MENU_PID      1       //PID CONFIG
+  #define MENU_RC       2       //RC TUNING
+  #define MENU_VOLTAGE  3       //VOLTAGE
+  #define MENU_RSSI     4       //RSSI
+  #define MENU_CURRENT  5       //CURRENT
+  #define MENU_DISPLAY  6       //DISPLAY
+  #define MENU_ADVANCED 7       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   8       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
 #ifdef NOCONTROLLER
@@ -238,8 +238,8 @@
   #undef  GPSACTIVECHECK
   #undef  OSD_SWITCH_RC
   #define ALWAYSARMED
-  #define MENU0  0 //STATISTICS
-  #define MAXPAGE MENU0   
+  #define MENU_STAT  0 //STATISTICS
+  #define MAXPAGE MENU_STAT
 #endif
 
 #ifdef HAS_ALARMS
@@ -379,23 +379,23 @@
   #undef  OSD_SWITCH_RC
   #define FORCESENSORS
   #define HIDEARMEDSTATUS
-  #define GPSACTIVECHECK 5  
+  #define GPSACTIVECHECK 5
 
-  #define MENU0  0 //STATISTICS
-//  #define MENU1  X //PID CONFIG
-//  #define MENU2  X //RC TUNING
-  #define MENU3  1 //VOLTAGE
-  #define MENU4  2 //RSSI
-  #define MENU5  3 //CURRENT
-  #define MENU6  4 //DISPLAY
-  #define MENU7  5 //ADVANCED
-//  #define MENU8  X //GPS TIME
-  #define MENU9  6 //ALARMS
-//  #define MENU10 9//PROFILE+PID CONTROLLER
-  #define MAXPAGE MENU9   
+  #define MENU_STAT     0       //STATISTICS
+//  #define MENU_PID  X //PID CONFIG
+//  #define MENU_RC  X //RC TUNING
+  #define MENU_VOLTAGE  1       //VOLTAGE
+  #define MENU_RSSI     2       //RSSI
+  #define MENU_CURRENT  3       //CURRENT
+  #define MENU_DISPLAY  4       //DISPLAY
+  #define MENU_ADVANCED 5       //ADVANCED
+//  #define MENU_GPS_TIME  X //GPS TIME
+  #define MENU_ALARMS   6       //ALARMS
+//  #define MENU_PROFILE 9//PROFILE+PID CONTROLLER
+  #define MAXPAGE       MENU_ALARMS
 #endif
 
-#if defined (OSD_SWITCH_RSSI)  
+#if defined (OSD_SWITCH_RSSI)
   #define OSD_SWITCH_RC
 #endif
 

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -1090,37 +1090,37 @@ const PROGMEM char * const menu_profile[] =
 
 const PROGMEM char * const menutitle_item[] = 
 {   
-#ifdef MENU0
+#ifdef MENU_STAT
   configMsg00,
 #endif
-#ifdef MENU1
+#ifdef MENU_PID
   configMsg10,
 #endif
-#ifdef MENU2
+#ifdef MENU_RC
   configMsg20,
 #endif
-#ifdef MENU3
+#ifdef MENU_VOLTAGE
   configMsg30,
 #endif
-#ifdef MENU4
+#ifdef MENU_RSSI
   configMsg40,
 #endif
-#ifdef MENU5
+#ifdef MENU_CURRENT
   configMsg50,
 #endif
-#ifdef MENU6
+#ifdef MENU_DISPLAY
   configMsg60,
 #endif
-#ifdef MENU7
+#ifdef MENU_ADVANCED
   configMsg70,
 #endif
-#ifdef MENU8
+#ifdef MENU_GPS_TIME
   configMsg80,
 #endif
-#ifdef MENU9
+#ifdef MENU_ALARMS
   configMsg90,
 #endif
-#ifdef MENU10
+#ifdef MENU_PROFILE
   configMsg100,
 #endif
 };

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1086,8 +1086,8 @@ void displayCursor(void)
   }
   if(ROW<10)
     {
-#ifdef MENU1
-    if(configPage==MENU1){
+#ifdef MENU_PID
+    if(configPage==MENU_PID){
       if (ROW==8) ROW=10;
       if (ROW==9) ROW=7;
       if(COL==1) cursorpos=(ROW+2)*30+10;
@@ -1095,14 +1095,14 @@ void displayCursor(void)
       if(COL==3) cursorpos=(ROW+2)*30+10+6+6;
      }
 #endif
-#ifdef MENU2
+#ifdef MENU_RC
   #if defined CORRECT_MENU_RCT2
-     if(configPage==MENU2){  
+     if(configPage==MENU_RC){
       COL=3;
       cursorpos=(ROW+2)*30+10+6+6;
     }
   #elif defined CORRECT_MENU_RCT1
-    if(configPage==MENU2)
+    if(configPage==MENU_RC)
     {  
       if (ROW==9){
         if (oldROW==8)
@@ -1115,7 +1115,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
       }
   #else
-    if(configPage==MENU2){
+    if(configPage==MENU_RC){
       COL=3;
       if (ROW==8) ROW=10;
       if (ROW==9) ROW=7;
@@ -1124,24 +1124,24 @@ void displayCursor(void)
   #endif
       
 #endif
-#ifdef MENU3      
-    if(configPage==MENU3){
+#ifdef MENU_VOLTAGE
+    if(configPage==MENU_VOLTAGE){
       COL=3;
       if (ROW==8) ROW=10;
       if (ROW==9) ROW=7;
       cursorpos=(ROW+2)*30+10+6+6;     
       }
 #endif
-#ifdef MENU4      
-    if(configPage==MENU4){
+#ifdef MENU_RSSI
+    if(configPage==MENU_RSSI){
       COL=3;
       if (ROW==7) ROW=10;
       if (ROW==9) ROW=6;
       cursorpos=(ROW+2)*30+10+6+6;
       }    
 #endif
-#ifdef MENU5      
-    if(configPage==MENU5)
+#ifdef MENU_CURRENT
+    if(configPage==MENU_CURRENT)
       {  
       COL=3;
       if (ROW==9) ROW=5;
@@ -1149,8 +1149,8 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif
-#ifdef MENU6      
-    if(configPage==MENU6)
+#ifdef MENU_DISPLAY
+    if(configPage==MENU_DISPLAY)
       {  
         if (ROW==9){
           if (oldROW==8)
@@ -1163,8 +1163,8 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif
-#ifdef MENU7      
-    if(configPage==MENU7)
+#ifdef MENU_ADVANCED
+    if(configPage==MENU_ADVANCED)
       {  
       COL=3;
       if (ROW==9) ROW=6;
@@ -1172,8 +1172,8 @@ void displayCursor(void)
        cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif
-#ifdef MENU8      
-    if(configPage==MENU8)
+#ifdef MENU_GPS_TIME
+    if(configPage==MENU_GPS_TIME)
       {  
       COL=3;
       if (ROW==9) ROW=3;
@@ -1181,8 +1181,8 @@ void displayCursor(void)
        cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif     
-#ifdef MENU9      
-    if(configPage==MENU9)
+#ifdef MENU_ALARMS
+    if(configPage==MENU_ALARMS)
       {  
       COL=3;
       if (ROW==9) ROW=6;
@@ -1190,8 +1190,8 @@ void displayCursor(void)
        cursorpos=(ROW+2)*30+10+6+6;
       }
 #endif     
-#ifdef MENU10      
-    if(configPage==MENU10)
+#ifdef MENU_PROFILE
+    if(configPage==MENU_PROFILE)
       {  
       #ifdef CORRECTLOOPTIME
         if (ROW==9) ROW=3;
@@ -1216,7 +1216,7 @@ void displayConfigScreen(void)
   int16_t MenuBuffer[10];
   strcpy_P(screenBuffer, (char*)pgm_read_word(&(menutitle_item[configPage])));
   MAX7456_WriteString(screenBuffer, 35);
-  #ifdef MENU10
+  #ifdef MENU_PROFILE
 //   MAX7456_WriteString(itoa(FCProfile,screenBuffer,10),50); // Display Profile number
   #endif 
   MAX7456_WriteString_P(configMsgEXT, SAVEP);    //EXIT
@@ -1225,7 +1225,7 @@ void displayConfigScreen(void)
     MAX7456_WriteString_P(configMsgPGS, SAVEP+16); //<Page>
   }
 
-  if(configPage==MENU0)
+  if(configPage==MENU_STAT)
   {
     int xx;
 //    MAX7456_WriteString_P(configMsg00, 35);
@@ -1264,8 +1264,8 @@ void displayConfigScreen(void)
 #endif
 
     }
-#ifdef MENU1
-  if(configPage==MENU1)
+#ifdef MENU_PID
+  if(configPage==MENU_PID)
   {
     for(uint8_t X=0; X<=6; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_pid[X])));
@@ -1288,8 +1288,8 @@ void displayConfigScreen(void)
     MAX7456_WriteString("D",83);
   }
 #endif
-#ifdef MENU2
-  if(configPage==MENU2)
+#ifdef MENU_RC
+  if(configPage==MENU_RC)
   {
     #if defined CORRECT_MENU_RCT2
       MenuBuffer[0]=rcRate8;
@@ -1336,8 +1336,8 @@ void displayConfigScreen(void)
     #endif
   }
 #endif
-#ifdef MENU3
-  if(configPage==MENU3)
+#ifdef MENU_VOLTAGE
+  if(configPage==MENU_VOLTAGE)
   {
     ProcessSensors();
     screenBuffer[0]=SYM_MAIN_BATT;
@@ -1366,8 +1366,8 @@ void displayConfigScreen(void)
     Menuconfig_onoff(MAGD,S_MAINVOLTAGE_VBAT);
   }
 #endif
-#ifdef MENU4
-  if(configPage==MENU4)
+#ifdef MENU_RSSI
+  if(configPage==MENU_RSSI)
   {
     itoa(rssi,screenBuffer,10);
     uint8_t xx = FindNull();
@@ -1391,8 +1391,8 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings16[S16_RSSIMIN],screenBuffer,10),LEVD);
   }
 #endif
-#ifdef MENU5
-  if(configPage==MENU5)
+#ifdef MENU_CURRENT
+  if(configPage==MENU_CURRENT)
   {
     ItoaPadded(amperage, screenBuffer, 4, 3);     // 99.9 ampere max!
     screenBuffer[4] = SYM_AMP;
@@ -1410,8 +1410,8 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings16[S16_AMPZERO],screenBuffer,10),VELD);
   }
 #endif
-#ifdef MENU6
-  if(configPage==MENU6)
+#ifdef MENU_DISPLAY
+  if(configPage==MENU_DISPLAY)
   {
     for(uint8_t X=0; X<=7; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_display[X])));
@@ -1427,8 +1427,8 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings[S_MAPMODE],screenBuffer,10),MAGD+LINE);
   }
 #endif
-#ifdef MENU7
-  if(configPage==MENU7)
+#ifdef MENU_ADVANCED
+  if(configPage==MENU_ADVANCED)
   {
     for(uint8_t X=0; X<=5; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_advanced[X])));
@@ -1474,8 +1474,8 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings[S_RCWSWITCH_CH],screenBuffer,10),LEVD);
    }
 #endif
-#ifdef MENU8
-  if(configPage==MENU8)
+#ifdef MENU_GPS_TIME
+  if(configPage==MENU_GPS_TIME)
   {
     for(uint8_t X=0; X<=2; X++) {
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_gps_time[X])));
@@ -1486,8 +1486,8 @@ void displayConfigScreen(void)
   MAX7456_WriteString(itoa(Settings[S_GPSTZ],screenBuffer,10),YAWD);
   }    
 #endif  
-#ifdef MENU9
-    if(configPage==MENU9){
+#ifdef MENU_ALARMS
+    if(configPage==MENU_ALARMS){
       MenuBuffer[0]=Settings[S_DISTANCE_ALARM];
       MenuBuffer[1]=Settings[S_ALTITUDE_ALARM];
       MenuBuffer[2]=Settings[S_SPEED_ALARM];
@@ -1501,8 +1501,8 @@ void displayConfigScreen(void)
       }
     }
 #endif  
-#ifdef MENU10
-    if(configPage==MENU10){
+#ifdef MENU_PROFILE
+    if(configPage==MENU_PROFILE){
       #ifdef CORRECTLOOPTIME
         #define MENU10MAX 2
       #else

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -617,11 +617,11 @@ void handleRawRC() {
       { 
 	waitStick =1;
         menudir=1+oldmenudir;
-        #ifdef MENU9
-	if(configPage == MENU9 && COL == 3) {
+        #ifdef MENU_ALARMS
+	if(configPage == MENU_ALARMS && COL == 3) {
 	  if(ROW==5) timer.magCalibrationTimer=0;
         }
-        #endif //MENU9
+        #endif //MENU_ALARMS
         serialMenuCommon();  
       }      
     }
@@ -644,8 +644,8 @@ void serialMenuCommon()
     }
     if(configPage<MINPAGE) configPage = MAXPAGE;
     if(configPage>MAXPAGE) configPage = MINPAGE;
-#ifdef MENU1
-	if(configPage == MENU1) {
+#ifdef MENU_PID
+	if(configPage == MENU_PID) {
 	  if(ROW >= 1 && ROW <= 7) {
             uint8_t MODROW=ROW-1;
             if (ROW>5){
@@ -657,9 +657,9 @@ void serialMenuCommon()
 	  }
 	}
 #endif
-#ifdef MENU2
+#ifdef MENU_RC
         #if defined CORRECT_MENU_RCT2
-          if(configPage == MENU2 && COL == 3) {
+          if(configPage == MENU_RC && COL == 3) {
 	    if(ROW==1) rcRate8=rcRate8+menudir;
 	    if(ROW==2) rcExpo8=rcExpo8+menudir;
 	    if(ROW==3) rollRate=rollRate+menudir;
@@ -671,7 +671,7 @@ void serialMenuCommon()
 	    if(ROW==9) tpa_breakpoint16=tpa_breakpoint16+menudir;
           }
         #elif defined CORRECT_MENU_RCT1
-          if(configPage == MENU2 && COL == 3) {
+          if(configPage == MENU_RC && COL == 3) {
 	    if(ROW==1) rcRate8=rcRate8+menudir;
 	    if(ROW==2) rcExpo8=rcExpo8+menudir;
 	    if(ROW==3) rollRate=rollRate+menudir;
@@ -682,7 +682,7 @@ void serialMenuCommon()
 	    if(ROW==8) thrExpo8=thrExpo8+menudir;
          }
         #else
-          if(configPage == MENU2 && COL == 3) {
+          if(configPage == MENU_RC && COL == 3) {
 	    if(ROW==1) rcRate8=rcRate8+menudir;
 	    if(ROW==2) rcExpo8=rcExpo8+menudir;
 	    if(ROW==3) rollPitchRate=rollPitchRate+menudir;
@@ -693,8 +693,8 @@ void serialMenuCommon()
 	  }
         #endif
 #endif
-#ifdef MENU3
-	if(configPage == MENU3 && COL == 3) {
+#ifdef MENU_VOLTAGE
+	if(configPage == MENU_VOLTAGE && COL == 3) {
 	  if(ROW==1) Settings[S_DISPLAYVOLTAGE]=!Settings[S_DISPLAYVOLTAGE];  
 	  if(ROW==2) Settings[S_DIVIDERRATIO]=Settings[S_DIVIDERRATIO]+menudir;
 	  if(ROW==3) Settings[S_VOLTAGEMIN]=Settings[S_VOLTAGEMIN]+menudir;
@@ -704,8 +704,8 @@ void serialMenuCommon()
 	  if(ROW==7) Settings[S_MAINVOLTAGE_VBAT]=!Settings[S_MAINVOLTAGE_VBAT];
 	}
 #endif
-#ifdef MENU4
-	if(configPage == MENU4 && COL == 3) {
+#ifdef MENU_RSSI
+	if(configPage == MENU_RSSI && COL == 3) {
 	  if(ROW==1) Settings[S_DISPLAYRSSI]=!Settings[S_DISPLAYRSSI];
 	  if(ROW==2) timer.rssiTimer=15; // 15 secs to turn off tx anwait to read min RSSI
 	  if(ROW==3) Settings[S_MWRSSI]=!Settings[S_MWRSSI];
@@ -714,8 +714,8 @@ void serialMenuCommon()
 	  if(ROW==6) Settings16[S16_RSSIMIN]=Settings16[S16_RSSIMIN]+menudir;
 	}
 #endif
-#ifdef MENU5
-	if(configPage == MENU5 && COL == 3) {
+#ifdef MENU_CURRENT
+	if(configPage == MENU_CURRENT && COL == 3) {
 	  if(ROW==1) Settings[S_AMPERAGE]=!Settings[S_AMPERAGE];
 	  if(ROW==2) Settings[S_AMPER_HOUR]=!Settings[S_AMPER_HOUR];
 	  if(ROW==3) Settings[S_AMPERAGE_VIRTUAL]=!Settings[S_AMPERAGE_VIRTUAL];
@@ -723,8 +723,8 @@ void serialMenuCommon()
 	  if(ROW==5) Settings16[S16_AMPZERO]=Settings16[S16_AMPZERO]+menudir;
 	}
 #endif
-#ifdef MENU6
-	if(configPage == MENU6 && COL == 3) {
+#ifdef MENU_DISPLAY
+	if(configPage == MENU_DISPLAY && COL == 3) {
 	  if(ROW==1) Settings[S_DISPLAY_HORIZON_BR]=!Settings[S_DISPLAY_HORIZON_BR];
 	  if(ROW==2) Settings[S_WITHDECORATION]=!Settings[S_WITHDECORATION];
 	  if(ROW==3) Settings[S_SCROLLING]=!Settings[S_SCROLLING];
@@ -735,8 +735,8 @@ void serialMenuCommon()
 	  if(ROW==8) Settings[S_MAPMODE]=Settings[S_MAPMODE]+menudir;
 	}
 #endif
-#ifdef MENU7
-	if(configPage == MENU7 && COL == 3) {
+#ifdef MENU_ADVANCED
+	if(configPage == MENU_ADVANCED && COL == 3) {
 	  if(ROW==1) Settings[S_UNITSYSTEM]=!Settings[S_UNITSYSTEM];
 	  if(ROW==2) {
 	    Settings[S_VIDEOSIGNALTYPE]=!Settings[S_VIDEOSIGNALTYPE];
@@ -747,15 +747,15 @@ void serialMenuCommon()
 	  if(ROW==5) timer.magCalibrationTimer=CALIBRATION_DELAY;
 	  if(ROW==6) Settings[S_RCWSWITCH_CH]=Settings[S_RCWSWITCH_CH]+menudir;	}
 #endif
-#ifdef MENU8
-	if(configPage == MENU8 && COL == 3) {
+#ifdef MENU_GPS_TIME
+	if(configPage == MENU_GPS_TIME && COL == 3) {
 	  if(ROW==1) Settings[S_GPSTIME]=!Settings[S_GPSTIME];
 	  if(ROW==2) Settings[S_GPSTZAHEAD]=!Settings[S_GPSTZAHEAD];
 	  if(ROW==3) if((menudir == 1 && Settings[S_GPSTZ] < 130) || (menudir == -1 && Settings[S_GPSTZ] > 0))Settings[S_GPSTZ]=Settings[S_GPSTZ]+menudir*5;
 	}
 #endif
-#ifdef MENU9
-	if(configPage == MENU9 && COL == 3) {
+#ifdef MENU_ALARMS
+	if(configPage == MENU_ALARMS && COL == 3) {
 	  if(ROW==1) Settings[S_DISTANCE_ALARM]=Settings[S_DISTANCE_ALARM]+menudir;
 	  if(ROW==2) Settings[S_ALTITUDE_ALARM]=Settings[S_ALTITUDE_ALARM]+menudir;
 	  if(ROW==3) Settings[S_SPEED_ALARM]=Settings[S_SPEED_ALARM]+menudir;
@@ -764,8 +764,8 @@ void serialMenuCommon()
 	  if(ROW==6) Settings[S_AMPERAGE_ALARM]=Settings[S_AMPERAGE_ALARM]+menudir;
 	}
 #endif
-#ifdef MENU10
-	if(configPage == MENU10 && COL == 3) {
+#ifdef MENU_PROFILE
+	if(configPage == MENU_PROFILE && COL == 3) {
 	  if(ROW==1) FCProfile=FCProfile+menudir;
 	  if(ROW==2) PIDController=PIDController+menudir;
         #ifdef CORRECTLOOPTIME


### PR DESCRIPTION
This reduces confusion considerably when looking at things like this:

    #define MENU9  8 //ALARMS

vs.

    #define MENU_ALARMS  8 //ALARMS

(I didn't remove these comments, though they become unnecessary once the
labels are clearer).

There are a lot of things in here that seem to be named with numbers and many have comments that describe what the numbers mean, but I think it's a bit easier if we just call the things what we intend for them to be.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shikofthera/scarab-osd/190)
<!-- Reviewable:end -->
