### PR TITLE
Fix logical AND mistakenly coded as bitwise AND

### DIFF
--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -483,7 +483,7 @@ void displayHorizon(int rollAngle, int pitchAngle)
 
   #ifdef SBDIRECTION
 
-    if (Settings[S_SIDEBARTOPS]&fieldIsVisible(SideBarScrollPosition)) {
+    if (Settings[S_SIDEBARTOPS]&&fieldIsVisible(SideBarScrollPosition)) {
       if (millis()<(sidebarsMillis + 1000)) {
         if (sidebarsdir == 2){
           screen[position-(hudheight*LINE)-hudwidth] = SYM_AH_DECORATION_UP;


### PR DESCRIPTION
I found this while I was working on some other stuff. I don't know the semantics associated with this if statement, but it looks like the && is the correct choice.