### PR TITLE
Problem indicator for #213

### DIFF
--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -158,7 +158,7 @@ void serialMSPCheck()
     MwSensorPresent = read16();
     MwSensorActive = read32();
     #ifndef MAVLINK   
-    MwSensorActive = read32();
+    // MwSensorActive = read32(); XXX This causes read32() called twice for !MAV
     #endif //MAVLINK
     #if defined FORCESENSORS
       MwSensorPresent=GPSSENSOR|BAROMETER|MAGNETOMETER|ACCELEROMETER;


### PR DESCRIPTION
This PR is only intended to show the location of the problem with #213 (MAVLINK telemetry support).

The highlighted (XXX) line causes read32() to be called twice for MwSensorActive when MAVLINK is not defined, breaking MSP protocol.

Sorry, can't fix it without the knowledge about the MAVLINK protocol.
