### PR TITLE
Prevent invalid request from being sent

### DIFF
--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -392,7 +392,6 @@ void loop()
       mspWriteRequest(MSPcmdsend, 0);      
       #endif //GPSOSD
       MAX7456_DrawScreen();
-
     }
 
     ProcessSensors();       // using analogue sensors
@@ -665,7 +664,9 @@ void setMspRequests() {
       REQ_MSP_IDENT|
       REQ_MSP_STATUS|
       REQ_MSP_RAW_GPS|
+#ifdef MSP_SPEED_LOW
       REQ_MSP_ATTITUDE|
+#endif
       REQ_MSP_RAW_IMU|
       REQ_MSP_ALTITUDE|
       REQ_MSP_RC_TUNING|
@@ -705,7 +706,11 @@ void setMspRequests() {
      #ifdef HAS_ALARMS
       REQ_MSP_ALARMS|
      #endif
-      REQ_MSP_ATTITUDE;
+#ifdef MSP_SPEED_LOW
+      REQ_MSP_ATTITUDE|
+#endif
+      0; // Sigh...
+
     if(MwSensorPresent&BAROMETER){ 
       modeMSPRequests |= REQ_MSP_ALTITUDE;
     }


### PR DESCRIPTION
Invalid request (request code 0x00) is sent from request scheduler for MSP_SPEED_{HI,MED} config cases, as an artifact of having REQ_MSP_ATTITUDE in the modeMSPRequest for these cases.

Including it only for the MSP_SPEED_LOW resolves the issue.
