### PR TITLE
Be specific on sizeof MwAngle

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -549,7 +549,7 @@ int32_t  MwAltitude=0;                         // This hold barometric value
 int32_t  old_MwAltitude=0;                     // This hold barometric value
 
 
-int MwAngle[2]={0,0};           // Those will hold Accelerator Angle
+int16_t MwAngle[2]={0,0};           // Those will hold Accelerator Angle
 static uint16_t MwRcData[8]={   // This hold receiver pulse signal
   1500,1500,1500,1500,1500,1500,1500,1500} ;
 

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -549,7 +549,7 @@ int32_t  MwAltitude=0;                         // This hold barometric value
 int32_t  old_MwAltitude=0;                     // This hold barometric value
 
 
-int16_t MwAngle[2]={0,0};           // Those will hold Accelerator Angle
+int16_t MwAngle[2]={0,0};           // Those will hold Accelerometer Angle
 static uint16_t MwRcData[8]={   // This hold receiver pulse signal
   1500,1500,1500,1500,1500,1500,1500,1500} ;
 


### PR DESCRIPTION
Not a big deal, sorta tidying.

MwAngle was one of the few variables in `GlobalVariables.h`, and the only variable in the Mw-series, without the specific size.

P.S.
Well, actually, this change will make assignment
`MwAngle[i] = read16();`
valid under 32-bit environment also :)
