### PR TITLE
This commit fixes issue #235 (MSP_PIDNAMES not implemented)

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -3,8 +3,8 @@
 
 /********************       OSD HARDWARE settings      *********************/
 //Choose ONLY ONE option:
-#define MINIMOSD                    // Uncomment this if using standard MINIMOSD hardware
-//#define MICROMINIMOSD             // Uncomment this if using the MICRO MINIMOSD hardware
+//#define MINIMOSD                    // Uncomment this if using standard MINIMOSD hardware
+#define MICROMINIMOSD             // Uncomment this if using the MICRO MINIMOSD hardware
 //#define RTFQV1                    // Uncomment this if using standard RTFQ/Witespy V1.1 OSD, select this to correct for both swapped bat1/bat 2 and to also use alternative resistors / pinouts.  
 //#define RTFQMICRO                 // Uncomment this if using micro RTFQ/Witespy Micro Minim OSD, select this to correct for swapped bat1/bat 2.  
 //#define RUSHDUINO                 // Uncomment this if using Rushduino
@@ -27,6 +27,7 @@
 // latest release...
 //#define MULTIWII                  // Uncomment this if you are using latest MULTIWII version from repository (2.4 at time of this MWOSD release)
 //#define BASEFLIGHT                // Uncomment this if you are using latest BASEFLIGHT version from repository (Stable 2015.08.27 at time of this MWOSD release)
+#define LIBREPILOT                 // Uncomment this if you are using the latest LibrePilot MSP Module
 //#define TAULABS                   // Uncomment this if you are using the latest Tau Labs MSP Module
 //#define DRONIN                    // Uncomment this if you are using the latest DRONIN MSP Module
 //#define CLEANFLIGHT               // Uncomment this if you are using latest CLEANFLIGHT version from repository (1.11.0 at time of this MWOSD release)

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -42,6 +42,11 @@
   #define TAULABS
 #endif
 
+#ifdef LIBREPILOT
+  #define TAULABS
+  #define USE_MSP_PIDNAMES
+#endif
+
 #ifdef CLEANFLIGHT    //set up latest at time of release
   #define CLEANFLIGHT190
 #endif

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -833,6 +833,8 @@ const char configMsg06[] PROGMEM = "MAH USED";
 const char configMsg07[] PROGMEM = "MAX AMPS";
 //-----------------------------------------------------------Page1
 const char configMsg10[] PROGMEM = "PID CONFIG";
+
+#ifndef USE_MSP_PIDNAMES
 const char configMsg11[] PROGMEM = "ROLL";
 const char configMsg12[] PROGMEM = "PITCH";
 const char configMsg13[] PROGMEM = "YAW";
@@ -840,6 +842,8 @@ const char configMsg14[] PROGMEM = "ALT";
 const char configMsg15[] PROGMEM = "GPS";
 const char configMsg16[] PROGMEM = "LEVEL";
 const char configMsg17[] PROGMEM = "MAG";
+#endif /* !USE_MSP_PIDNAMES */
+
 //-----------------------------------------------------------Page2
 const char configMsg20[] PROGMEM = "RC TUNING";
 const char configMsg21[] PROGMEM = "RC RATE";
@@ -975,6 +979,7 @@ const unsigned char MwGPSAltPositionAdd[2]={
 #define REQ_MSP_PID_CONTROLLER  262144  // (1 << 18)
 #define REQ_MSP_LOOP_TIME       524288  // (1 << 19) 
 #define REQ_MSP_FW_CONFIG       1048576 // (1 << 20) 
+#define REQ_MSP_PIDNAMES (1L<<21)
 
 // Menu selections
 const PROGMEM char * const menu_choice_unit[] =
@@ -1007,6 +1012,14 @@ const PROGMEM char * const menu_stats_item[] =
   configMsg07,
 };
 
+#ifdef USE_MSP_PIDNAMES
+
+#define PIDNAME_BUFSIZE  8
+#define PIDNAME_NUMITEMS 7
+
+char menu_pid[PIDNAME_NUMITEMS][PIDNAME_BUFSIZE];
+
+#else /* USE_MSP_PIDNAMES */
 const PROGMEM char * const menu_pid[] = 
 {   
   configMsg11,
@@ -1017,6 +1030,7 @@ const PROGMEM char * const menu_pid[] =
   configMsg16,
   configMsg17,
 };
+#endif
 
 const PROGMEM char * const menu_rc[] = 
 {   

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -347,6 +347,11 @@ void loop()
       case REQ_MSP_PID:
         MSPcmdsend = MSP_PID;
         break;
+#ifdef USE_MSP_PIDNAMES
+      case REQ_MSP_PIDNAMES:
+        MSPcmdsend = MSP_PIDNAMES;
+        break;
+#endif
       case REQ_MSP_LOOP_TIME:
         MSPcmdsend = MSP_LOOP_TIME;
         break;        
@@ -677,6 +682,9 @@ void setMspRequests() {
       REQ_MSP_ALTITUDE|
       REQ_MSP_RC_TUNING|
       REQ_MSP_PID_CONTROLLER|
+#ifdef USE_MSP_PIDNAMES
+      REQ_MSP_PIDNAMES|
+#endif
       REQ_MSP_PID|
       REQ_MSP_LOOP_TIME|
 #ifdef CORRECT_MSP_BF1

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1322,9 +1322,14 @@ void displayConfigScreen(void)
 #ifdef MENU_PID
   if(configPage==MENU_PID)
   {
+
     for(uint8_t X=0; X<=6; X++) {
+#ifdef USE_MSP_PIDNAMES
+      MAX7456_WriteString(menu_pid[X], ROLLT+ (X*30));
+#else
       strcpy_P(screenBuffer, (char*)pgm_read_word(&(menu_pid[X])));
       MAX7456_WriteString(screenBuffer, ROLLT+ (X*30));
+#endif
     }
    
     for(uint8_t Y=0; Y<=8; Y++) {      

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -386,7 +386,43 @@ void serialMSPCheck()
       modeMSPRequests &=~ REQ_MSP_RC_TUNING;
     #endif
   }
+#ifdef USE_MSP_PIDNAMES
+  if (cmdMSP==MSP_PIDNAMES)
+  {
+      // parse buffer and fill menu_pid[]. We need to receive all bytes, but store only ones that we need
+      
+      uint8_t pn_index = 0, avail = (PIDNAME_BUFSIZE - 1), c;
+      uint8_t *out = (uint8_t *)menu_pid;
 
+      for(uint8_t i = 0; i<dataSize; i++) {
+        c = read8();
+
+        if((pn_index != 5) && (pn_index != 6) && (pn_index <= 8)) // 5, 6 and >8 are skipped
+        {
+          if(c == ';')
+          {
+             *out = 0;
+
+              out += avail + 1;
+              
+              avail = PIDNAME_BUFSIZE - 1;
+          }
+          else if(avail > 0)
+          {
+             *out++ = c;
+             --avail;
+          }
+        }
+
+        if(c == ';')
+        {
+           ++pn_index;
+        }
+      
+      }
+      modeMSPRequests &= ~REQ_MSP_PIDNAMES;
+  }
+#endif
   if (cmdMSP==MSP_PID)
   {
     for(uint8_t i=0; i<PIDITEMS; i++) {


### PR DESCRIPTION
Enabling USE_MSP_PIDNAMES feature memory footprint is increased by 56 bytes of FLASH space and 56 bytes of RAM.


```
Without USE_MSP_PIDNAMES
Sketch uses 25,086 bytes (81%) of program storage space. Maximum is 30,720 bytes.
Global variables use 1,581 bytes (77%) of dynamic memory, leaving 467 bytes for local variables. Maximum is 2,048 bytes.

With USE_MSP_PIDNAMES
Sketch uses 25,142 bytes (81%) of program storage space. Maximum is 30,720 bytes.
Global variables use 1,637 bytes (79%) of dynamic memory, leaving 411 bytes for local variables. Maximum is 2,048 bytes.
```
