### PR TITLE
Hide arm status messages if NOCONTROLLER

### DIFF
--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -285,7 +285,7 @@
   #undef  SATACTIVECHECK
   #undef  GPSACTIVECHECK
   #undef  OSD_SWITCH_RC
-  #define ALWAYSARMED
+  #define HIDEARMEDSTATUS
   #define MENU_STAT  0           //STATISTICS
   #define MAXPAGE MENU_STAT
 #endif


### PR DESCRIPTION
NOCONTROLLER should hide the arm status messages, just like GPSOSD case.