### PR TITLE
Fix up references from WITESPY to RTFQ

### DIFF
--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -337,35 +337,35 @@
 
 
 /********************  OSD HARDWARE rule definitions  *********************/
-#ifdef RUSHDUINO                     
-    # define MAX7456SELECT 10        // ss 
+#ifdef RUSHDUINO
+    # define MAX7456SELECT 10        // ss
     # define MAX7456RESET  9         // RESET
-#else                                  
+#else
     # define MAX7456SELECT 6         // ss
     # define MAX7456RESET  10        // RESET
 #endif
 
-#ifdef WITESPYV1                     
+#ifdef RTFQV1
     #define SWAPVOLTAGEPINS
     #define ALTERNATEDIVIDERS
 #endif
 
-#ifdef WITESPYMICRO                     
+#ifdef RTFQMICRO
     #define SWAPVOLTAGEPINS
 #endif
 
-#ifdef SWAPVOLTAGEPINS                     
+#ifdef SWAPVOLTAGEPINS
     #define VOLTAGEPIN    A2
     #define VIDVOLTAGEPIN A0
-#else                                  
+#else
     #define VOLTAGEPIN    A0
     #define VIDVOLTAGEPIN A2
 #endif
 
-#ifdef ALTERNATEDIVIDERS                     
-    #define DIVIDER1v1      0.0002      // Voltage divider for 1.1v reference. 
-    #define DIVIDER5v       0.0008      // Voltage divider for 5v reference. 
-#else                                  
+#ifdef ALTERNATEDIVIDERS
+    #define DIVIDER1v1      0.0002      // Voltage divider for 1.1v reference.
+    #define DIVIDER5v       0.0008      // Voltage divider for 5v reference.
+#else
     #define DIVIDER1v1      0.0001      // Voltage divider for 1.1v reference. Use 0.0001 default unless advised otherwise.
     #define DIVIDER5v       0.0005      // Voltage divider for 5v reference. Use 0.0005 default unless advised otherwise.
 #endif

--- a/OTHER/DOCUMENTATION/FAQ.md
+++ b/OTHER/DOCUMENTATION/FAQ.md
@@ -61,8 +61,8 @@
 9 My voltage doesn't change during flight
  * Check you have selected teh correct board in OSD HARDWARE settings
  * Check you have selected the correct battery option - FC if using FC connection
- * If using a micro board, you probably have to select WITESPYMICRO
- * If using a full size witespy board you may have to select WITESPY in config.h
+ * If using a micro board, you probably have to select RTFQMICRO
+ * If using a full size witespy board you may have to select RTFQV1 in config.h
  * Ensure you are connected to the correct vbat pin some are reversed bat1 / bat2
  * Enable SWAPVOLTAGEPINS if you don't want to swap physical wires.
 


### PR DESCRIPTION
Noticed this when working with a witespy microminim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shikofthera/scarab-osd/242)
<!-- Reviewable:end -->
