### PR TITLE
Remove AUTOCAMWAIT

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -189,7 +189,6 @@
 /********************       Display Settings         ************************/
 #define MAXSTALLDETECT              // Enable to attempt to detect MAX chip stall from bad power. Attempts to restart.
 //#define AUTOCAM                   // Disable if no screen display. Enables autodetect Camera type PAL/NTSC. Overrides GUI/OSD settings.
-//#define AUTOCAMWAIT               // **UNTESTED** - Use with AUTOCAM - waits until camera is ready - i.e. if power up cameras after FC. 
 #define DECIMAL '.'                 // Decimal point character, change to what suits you best (.) (,)
 #define USE_VSYNC                   // Disable if no screen display. Removes sparklies as updates screen during blanking time period. 
 //#define SHIFTDOWN                 // Select if your monitor cannot display top line fully. It shifts top 3 lines down. Not suitable for all layouts

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -155,17 +155,11 @@ void MAX7456Setup(void)
 #ifdef AUTOCAM 
   pinMode(MAX7456SELECT,OUTPUT);
   digitalWrite(MAX7456SELECT,LOW);
-  uint8_t srdata = 0;
-  #if defined AUTOCAMWAIT 
-    while ((B00000011 & srdata) == 0){
-      spi_transfer(0xa0);
-      srdata = spi_transfer(0xFF); 
-      delay(100);
-    }
-  #else  
-    spi_transfer(0xa0);
-    srdata = spi_transfer(0xFF); 
-  #endif //AUTOCAMWAIT  
+
+  uint8_t srdata;
+  spi_transfer(0xa0);
+  srdata = spi_transfer(0xFF); 
+
   if ((B00000001 & srdata) == B00000001){     //PAL
       Settings[S_VIDEOSIGNALTYPE]=1; 
   }


### PR DESCRIPTION
Remove the AUTOCAMWAIT option which became obsolete by continuous signal type checking.