### PR TITLE
Make AUTOCAM independent from MAXSTALLDETECT

### DIFF
--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -572,10 +572,10 @@ void loop()
     timer.seconds+=1000;
     timer.tenthSec=0;
     onTime++;
-    #ifdef MAXSTALLDETECT
+    #if defined(AUTOCAM) || defined(MAXSTALLDETECT)
       if (!fontMode)
-        MAX7456Stalldetect();
-    #endif 
+        MAX7456CheckStatus();
+    #endif
     #ifdef ALARM_GPS
       if (timer.GPS_active==0){
         GPS_numSat=0;

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -315,7 +315,8 @@ void write_NVM(uint8_t char_address)
 #endif
 }
 
-void MAX7456Stalldetect(void){
+#if defined(AUTOCAM) || defined(MAXSTALLDETECT)
+void MAX7456CheckStatus(void){
   static uint8_t MAX7456signaltype;
   uint8_t srdata;
   MAX7456ENABLE
@@ -331,12 +332,15 @@ void MAX7456Stalldetect(void){
   }
 #endif
 
+#ifdef MAXSTALLDETECT
   spi_transfer(0x80);
   srdata = spi_transfer(0xFF); 
   
   if ((B00001000 & srdata) == 0)
     MAX7456Setup(); 
+#endif
 }
+#endif
 
 #if defined LOADFONT_DEFAULT || defined LOADFONT_LARGE || defined LOADFONT_BOLD
 void displayFont()


### PR DESCRIPTION
The code is NOT tested. Intended as a memo.

The AUTOCAM code in MAX7456Stalldetect() is not executed if MAXSTALLDETECT is not defined (MAX7456Stalldetect() is not called unless MAXSTALLDETECT is defined).

Fix this by:
(1) Make a call to MAX7456Stalldetect() if AUTOCAM OR MAXSTALLDETECT is defined, and
(2) (optionally) rename the MAX7456Stalldetect() to MAX7456CheckStatus() because the function now does more than stall detection.