### PR TITLE
Only protect where should be atomic

### DIFF
--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -86,6 +86,7 @@ uint16_t UntouchedStack(void)
 #undef PROGMEM
 #define PROGMEM __attribute__(( section(".progmem.data") ))
 #include <EEPROM.h>
+#include <util/atomic.h> // For ATOMIC_BLOCK
 #include "Config.h"
 #include "Def.h"
 #include "symbols.h"

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -182,10 +182,10 @@ void MAX7456Setup(void)
   MAX7456DISABLE
 
 # ifdef USE_VSYNC
-  cli();
-  EIMSK |= (1 << INT0);  // enable interuppt
-  EICRA |= (1 << ISC01); // interrupt at the falling edge
-  sei();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    EIMSK |= (1 << INT0);  // enable interuppt
+    EICRA |= (1 << ISC01); // interrupt at the falling edge
+  }
 #endif
   readEEPROM_screenlayout();
 }

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -119,7 +119,6 @@ void MAX7456Setup(void)
   uint8_t MAX_screen_rows;
 
   // Set hardware as per def.h
-  cli();
   SETHARDWAREPORTS
   MAX7456HWRESET
   MAX7456DISABLE
@@ -183,6 +182,7 @@ void MAX7456Setup(void)
   MAX7456DISABLE
 
 # ifdef USE_VSYNC
+  cli();
   EIMSK |= (1 << INT0);  // enable interuppt
   EICRA |= (1 << ISC01); // interrupt at the falling edge
   sei();


### PR DESCRIPTION
I’m not too sure if the `cli()` was deliberately put at the beginning of the `MAX7456Setup()`, but …

1. If `USE_VSYNC` is not defined, `sei()` will never get called, which effectively freezes `Serial` operation.
2. General rule is that a non-interrupting periods should be as short as possible, protecting only a section of the code that should be executed atomically.

This PR is for 2.

If there are reasons for `cli()` to protect the entire duration of the `MAX7456Setup()`, `sei()` should be placed after the `#endif` for the `USE_VSYNC` to cover 1.