### PR TITLE
AUTOCAM behavior improvement and more stable reset

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -3,11 +3,11 @@
 
 /********************       OSD HARDWARE settings      *********************/
 //Choose ONLY ONE option:
-#define MINIMOSD                    // Uncomment this if using standard MINIMOSD hardware
+//#define MINIMOSD                    // Uncomment this if using standard MINIMOSD hardware
 //#define MICROMINIMOSD             // Uncomment this if using the MICRO MINIMOSD hardware
 //#define RTFQV1                    // Uncomment this if using standard RTFQ/Witespy V1.1 OSD, select this to correct for both swapped bat1/bat 2 and to also use alternative resistors / pinouts.  
 //#define RTFQMICRO                 // Uncomment this if using micro RTFQ/Witespy Micro Minim OSD, select this to correct for swapped bat1/bat 2.  
-//#define RUSHDUINO                 // Uncomment this if using Rushduino
+#define RUSHDUINO                 // Uncomment this if using Rushduino
 //#define KYLIN250PDB               // Uncomment this if using a Kylin 250 FPV PDB (Using A6 as VOLTAGEPIN)
 
 // NOTE-some of the popular RTFQ/Witespy boards have swapped bat1/bat2 pins and alternative voltage measuring resistors

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -402,14 +402,33 @@
     # define VSYNC             2 // INT0
     # define MAX7456RESET      9 // RESET
     # define MAX7456SELECT    10 // CHIP SELECT 
-    # define SETHARDWAREPORTS pinMode(MAX7456RESET,OUTPUT);pinMode(MAX7456SELECT,OUTPUT);pinMode(DATAOUT, OUTPUT);pinMode(DATAIN, INPUT);pinMode(SPICLOCK,OUTPUT);pinMode(VSYNC, INPUT);
-    # define MAX7456HWRESET   digitalWrite(MAX7456RESET,LOW);delay(100);digitalWrite(MAX7456RESET,HIGH);
+
+    # define MAX7456SETHWPORTS {\
+        pinMode(MAX7456RESET, OUTPUT);\
+        pinMode(MAX7456SELECT,OUTPUT);\
+        pinMode(DATAOUT,      OUTPUT);\
+        pinMode(DATAIN,       INPUT);\
+        pinMode(SPICLOCK,     OUTPUT);\
+        pinMode(VSYNC,        INPUT);}
+
+    /*
+     * Hardware reset.
+     * RESET low is min. 50msec by spec, and min. 40msec post-RESET delay is
+     * required for stable reset (pragmatically on Arduino Nano).
+     * (Anyone want to try polling STAT[6] == 0?)
+     */
+    # define MAX7456HWRESET {\
+        digitalWrite(MAX7456RESET,LOW);\
+        delay(60);\
+        digitalWrite(MAX7456RESET,HIGH);\
+        delay(40);}
+
     # define MAX7456ENABLE    digitalWrite(MAX7456SELECT,LOW); 
     # define MAX7456DISABLE   digitalWrite(MAX7456SELECT,HIGH); 
 #else                                  
     # define MAX7456ENABLE    PORTD&=B10111111; 
     # define MAX7456DISABLE   PORTD|=B01000000; 
-    # define SETHARDWAREPORTS DDRB|=B00101100;DDRB&=B11101111;DDRD|=B01000000;DDRD&=B11111101;
+    # define MAX7456SETHWPORTS DDRB|=B00101100;DDRB&=B11101111;DDRD|=B01000000;DDRD&=B11111101;
     # define MAX7456HWRESET   PORTB&=B11111011;delay(100);PORTB|=B00000100;
 #endif
 

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -138,6 +138,8 @@ void setup()
   pinMode(RSSIPIN, INPUT);
   pinMode(LEDPIN,OUTPUT);
 
+  MAX7456SETHWPORTS
+
 #if defined (INTPWMRSSI) || defined (PPMOSDCONTROL)
   initRSSIint();
 #endif


### PR DESCRIPTION
1. AUTOCAM was recording the camera type in a local static variable, which caused MAX7456Setup() to be called TWICE at startup, once from the initialization, and another from the first call to MAX7456CheckStatus(). An effect of two calls was visible as a short loss of sync after the video first become available.
Fixed this by declaring the camera type as global detectedCamType that is updated in the MAX7456Setup().

2. RUSHDUINO-Arduino (Nano) based hardware platform started to
experience hardware RESET failures. Fixed this by adding extra 40msec
delay after RESET is pulled high.
  May be applied to the non-RUSHDUINO case also?

3. MAX7456Setup() now executes MAX7456DISABLE before MAX7456HWRESET so
that MAX7456SELECT is high when the MAX gets out of RESET period.

4. Pin mode setup is now declared as MAX7456SETHWPORTS, and executed
only once at the beginning of the setup().

5. Tiding of RUSHDUINO macros for increased readability.