### PR TITLE
Autocam behavior improvement

### DIFF
--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -86,6 +86,7 @@ uint16_t UntouchedStack(void)
 #undef PROGMEM
 #define PROGMEM __attribute__(( section(".progmem.data") ))
 #include <EEPROM.h>
+#include <util/atomic.h> // For ATOMIC_BLOCK
 #include "Config.h"
 #include "Def.h"
 #include "symbols.h"

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -182,10 +182,10 @@ void MAX7456Setup(void)
   MAX7456DISABLE
 
 # ifdef USE_VSYNC
-  cli();
-  EIMSK |= (1 << INT0);  // enable interuppt
-  EICRA |= (1 << ISC01); // interrupt at the falling edge
-  sei();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    EIMSK |= (1 << INT0);  // enable interuppt
+    EICRA |= (1 << ISC01); // interrupt at the falling edge
+  }
 #endif
   readEEPROM_screenlayout();
 }

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -119,7 +119,6 @@ void MAX7456Setup(void)
   uint8_t MAX_screen_rows;
 
   // Set hardware as per def.h
-  cli();
   SETHARDWAREPORTS
   MAX7456HWRESET
   MAX7456DISABLE
@@ -183,6 +182,7 @@ void MAX7456Setup(void)
   MAX7456DISABLE
 
 # ifdef USE_VSYNC
+  cli();
   EIMSK |= (1 << INT0);  // enable interuppt
   EICRA |= (1 << ISC01); // interrupt at the falling edge
   sei();


### PR DESCRIPTION
`AUTOCAM / MAX7456CheckStatus()` was recording the camera type in a local static variable, which caused `MAX7456Setup()` to be called TWICE at startup, once during initialization and once from the first call to `MAX7456CheckStatus()`.
An effect of these two calls was visible as a short loss of sync, occuring one second after the video first become available.

Fixed this by declaring the camera type as global `detectedCamType` that is updated in the `MAX7456Setup()`.
In addition, short (about 1 frame) delay before sensing the cam type was inserted for consistent signal detection.

NOTE: Requires cli()-sei() patch (#277)