### PR TITLE
Consistent reset for duinos

### DIFF
--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -403,7 +403,7 @@
     # define MAX7456RESET      9 // RESET
     # define MAX7456SELECT    10 // CHIP SELECT 
     # define SETHARDWAREPORTS pinMode(MAX7456RESET,OUTPUT);pinMode(MAX7456SELECT,OUTPUT);pinMode(DATAOUT, OUTPUT);pinMode(DATAIN, INPUT);pinMode(SPICLOCK,OUTPUT);pinMode(VSYNC, INPUT);
-    # define MAX7456HWRESET   digitalWrite(MAX7456RESET,LOW);delay(100);digitalWrite(MAX7456RESET,HIGH);
+    # define MAX7456HWRESET   digitalWrite(MAX7456RESET,LOW);delay(60);digitalWrite(MAX7456RESET,HIGH);delay(40);
     # define MAX7456ENABLE    digitalWrite(MAX7456SELECT,LOW); 
     # define MAX7456DISABLE   digitalWrite(MAX7456SELECT,HIGH); 
 #else                                  

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -86,6 +86,7 @@ uint16_t UntouchedStack(void)
 #undef PROGMEM
 #define PROGMEM __attribute__(( section(".progmem.data") ))
 #include <EEPROM.h>
+#include <util/atomic.h> // For ATOMIC_BLOCK
 #include "Config.h"
 #include "Def.h"
 #include "symbols.h"

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -182,10 +182,10 @@ void MAX7456Setup(void)
   MAX7456DISABLE
 
 # ifdef USE_VSYNC
-  cli();
-  EIMSK |= (1 << INT0);  // enable interuppt
-  EICRA |= (1 << ISC01); // interrupt at the falling edge
-  sei();
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+    EIMSK |= (1 << INT0);  // enable interuppt
+    EICRA |= (1 << ISC01); // interrupt at the falling edge
+  }
 #endif
   readEEPROM_screenlayout();
 }

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -119,7 +119,6 @@ void MAX7456Setup(void)
   uint8_t MAX_screen_rows;
 
   // Set hardware as per def.h
-  cli();
   SETHARDWAREPORTS
   MAX7456HWRESET
   MAX7456DISABLE
@@ -183,6 +182,7 @@ void MAX7456Setup(void)
   MAX7456DISABLE
 
 # ifdef USE_VSYNC
+  cli();
   EIMSK |= (1 << INT0);  // enable interuppt
   EICRA |= (1 << ISC01); // interrupt at the falling edge
   sei();


### PR DESCRIPTION
After the MAX init change, my Arduino Nano and Adafruit Metro based boards started to experience reset failures. After some try and error, found out that 40msec delay after pulling RESET high solves the problem.

The reset pulse itself was shortened to spec. min. 50msec + alpha.

Note: cli()-sei() patch ( #277) is required to ensure the correct operation of delay().