### PR TITLE
Scale LTM RSSI as they are received (Solves issue #288)

### DIFF
--- a/MW_OSD/LTM.h
+++ b/MW_OSD/LTM.h
@@ -118,7 +118,7 @@ void ltm_check() {
       amperagesum = 360*dummy;
       MWAmperage  = 10*calculateCurrentFromConsumedCapacity(dummy);
     }
-    MwRssi = ltmread_u8();
+    MwRssi = ltmread_u8() * 4; // 0-255 to 0-1023 (1020, actually)
     dummy = ltmread_u8();
     uint8_t ltm_armfsmode = ltmread_u8();
     armed = (ltm_armfsmode & 0b00000001) ? 1 : 0;

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -959,7 +959,7 @@ void ProcessSensors(void) {
         }
       }
       if(Settings[S_MWRSSI]) {
-        sensortemp = MwRssi<<2;
+        sensortemp = MwRssi;
       }
     }
     //--- Apply filtering    


### PR DESCRIPTION
As per #288 

Tested with MSP (BF2.9) and LTM (CF1.13.0).