### PR TITLE
Handle negative amperage case correctly

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -643,7 +643,7 @@ static int16_t MwHeading=0;
 // For Amperage
 float amperage = 0;                // its the real value x10
 float amperagesum = 0;
-uint16_t MWAmperage=0;
+int16_t MWAmperage=0;
 
 // Rssi
 int16_t rssi =0;   // uint8_t ?

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -1033,7 +1033,11 @@ void ProcessSensors(void) {
     }  
   }
   else{
-    amperage = MWAmperage / AMPERAGE_DIV;
+    // Apply rounding math
+    if (MWAmperage < 0)
+      amperage = (MWAmperage - AMPERAGE_DIV / 2) / AMPERAGE_DIV;
+    else
+      amperage = (MWAmperage + AMPERAGE_DIV / 2) / AMPERAGE_DIV;
   }
 
 //-------------- RSSI

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -298,7 +298,7 @@ void serialMSPCheck()
     MwVBat=read8();
     pMeterSum=read16();
     MwRssi = read16();
-    MWAmperage = read16();
+    MWAmperage = (int16_t)read16();
  }
 
 #ifdef MENU_SERVO  


### PR DESCRIPTION
As per #293

Amperage in MSP_ANALOG is **_signed_** 16-bit integer (unless MultiWii mode is selected in which case the scale is also x10). Handle this correctly.

Proper rounding instead of simple truncation by integer division is also applied.
