### PR TITLE
MAVLINK.h : Fix radian to degree (deci-degree) calculation

### DIFF
--- a/MW_OSD/MAVLINK.h
+++ b/MW_OSD/MAVLINK.h
@@ -164,8 +164,8 @@ void serialMAVCheck(){
     MwVario=(int16_t)serialbufferfloat(12)*100;     // m/s-->cm/s
     break;
   case MAVLINK_MSG_ID_ATTITUDE:
-    MwAngle[0]=(int16_t)(serialbufferfloat(4)*57296/10);     // rad-->0.1deg
-    MwAngle[1]=(int16_t)(serialbufferfloat(8)*57296/10);     // rad-->0.1deg
+    MwAngle[0]=(int16_t)(serialbufferfloat(4)*57.2958*10); // rad-->0.1deg
+    MwAngle[1]=(int16_t)(serialbufferfloat(8)*57.2958*10); // rad-->0.1deg
     break;
   case MAVLINK_MSG_ID_GPS_RAW_INT:
 #ifdef ALARM_GPS


### PR DESCRIPTION
The current MAVLINK code scales attitude incorrectly:

> `MwAngle[0]=(int16_t)(serialbufferfloat(4)*57296/10);`

The correct formula is

>`deci-degree = radian * degree/radian * deci-degree/degree = radian * 57.2958 * 10`

(Original code produces x10 bigger value)

Since Arduino 1.6.8 compiler generates identical code for
    `(int16_t)(float_variable*572958/1000*10)`
and
    `(int16_t)(float_variable*57.2958*10)`
the latter is selected for clarity.