### PR TITLE
MAX ALTITUDE is taken over by MAX DISTANCE

### DIFF
--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1255,8 +1255,8 @@ void displayConfigScreen(void)
       else if ((X==2) &&(distanceMAX>9999)){
         formatDistance(distanceMAX,0,2);
       }
-      else if ((X==3) &&(distanceMAX>9999)){
-        formatDistance(distanceMAX,0,2);
+      else if ((X==3) &&(altitudeMAX>9999)){
+        formatDistance(altitudeMAX,0,2);
       }
       else{
         itoa(MenuBuffer[X],screenBuffer,10);


### PR DESCRIPTION
When `distanceMAX > 9999`, then `altitudeMAX` is over taken by `distanceMAX`.

```
1251 #ifdef LONG_RANGE_DISPLAY
1252       if ((X==1)){
1253         formatDistance(trip,0,2);
1254       }
1255       else if ((X==2) &&(distanceMAX>9999)){
1256         formatDistance(distanceMAX,0,2);
1257       }
1258       else if ((X==3) &&(distanceMAX>9999)){
1259         formatDistance(distanceMAX,0,2);
1260       }
1261       else{
1262         itoa(MenuBuffer[X],screenBuffer,10);
1263       }
```
The `X==3` case should use `altitudeMAX` for formatting in line 1259 at least, and probably use `altitudeMAX` for decision in 1258, too.

Whether to use Km units for max altitude is still under discussion.