### PR TITLE
Max software reset

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -16,7 +16,7 @@
 // #define ALTERNATEDIVIDERS        // For boards with voltage unable to be adjusted high enough
 
 // For hardwares WITHOUT access to MAX RESET pin (e.g. Airbot MicroOSD v2.3)
-#define MAX_SOFTRESET
+//#define MAX_SOFTRESET
 
 
 /********************       CONTROLLER SOFTWARE      *********************/

--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -15,6 +15,9 @@
 // #define SWAPVOLTAGEPINS          // For boards with batt voltage appearing on vid voltage
 // #define ALTERNATEDIVIDERS        // For boards with voltage unable to be adjusted high enough
 
+// For hardwares WITHOUT access to MAX RESET pin (e.g. Airbot MicroOSD v2.3)
+#define MAX_SOFTRESET
+
 
 /********************       CONTROLLER SOFTWARE      *********************/
 // Choose ONLY ONE option:-


### PR DESCRIPTION
As per #304.

Software only reset for MAX There are hardwares without MAX’s RESET pin not wired to M328 (e.g.
Airbot MicroOSD v2.3).

For such hardware, relying on hardware reset pin to bring MAX to known state fails, because MAX can be in the middle of an SPI transaction when M328 is reset.

The MAX7456SoftReset() will bring MAX to known state without using the hardware reset.

Needs MAX_SOFTRESET defined in Config.h
