### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ MW_OSD_GUI/data/GUI.Config
 MW_OSD_GUI/application.windows64/data/custom.mcm
 
 notes.txt
+
+.DS_Store


### PR DESCRIPTION
My git on macosx suddenly started to detect/complain about .DS_Store changes. I would like to ignore them!