### PR TITLE
Canvas mode support for BF-CMS and inverted char support

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -86,6 +86,8 @@
 //#define GPSTIME       // Enable/disable GPS Time functions
 //#define SPORT         // Enable/disable FRSKY S.PORT cell code
 
+//#define CANVAS_SUPPORT            // Enable CANVAS mode support for post betaflight 3.1.0 CMS
+//#define INVERTED_CHAR_SUPPORT     // Enable inverted char support
 
 /********************       TELEMETRY settings      *********************/
 //Select ONLY if you are sure your OSD is connected to a telemetry feed:

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -140,6 +140,8 @@
   #define MENU_ALARMS   9       //ALARMS
   #define MENU_PROFILE  10      //PROFILE+PID CONTROLLER
   #define MAXPAGE       MENU_PROFILE
+
+  #define CANVAS_SUPPORT
 #endif
 
 #if defined CLEANFLIGHT190

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -179,6 +179,14 @@ uint8_t cells=0;
   uint8_t bfconfig[25];
 #endif
 
+// Canvas mode
+#ifdef CANVAS_SUPPORT
+bool canvasMode = false;
+bool canvasFirst = true;
+uint32_t lastCanvas = 0;
+#define CANVAS_TIMO 2000  // Canvas mode timeout in msec.
+#endif
+
 // Config status and cursor location
 uint8_t screenlayout=0;
 uint8_t oldscreenlayout=0;
@@ -732,6 +740,8 @@ uint16_t flyingTime=0;
 #define MSP_BOXIDS               119   //out message         get the permanent IDs associated to BOXes
 #define MSP_SERVO_CONF           120    //out message         Servo settings
 #define MSP_NAV_STATUS           121   //out message	     Returns navigation status
+
+#define MSP_CANVAS               182
 
 #define MSP_CELLS                130   //out message         FrSky SPort Telemtry
 

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -107,7 +107,10 @@ uint16_t UntouchedStack(void)
 #include "WireUB.h"
 #endif
 
-char screen[480];      // Main screen ram for MAX7456
+char screen[480];          // Main screen ram for MAX7456
+#ifdef INVERTED_CHAR_SUPPORT
+uint8_t screenAttr[480/8]; // Attribute (INV) bits for each char in screen[]
+#endif
 char screenBuffer[20]; 
 uint32_t modeMSPRequests;
 uint32_t queuedMSPRequests;
@@ -301,7 +304,11 @@ void loop()
   if((currentMillis - previous_millis_sync) >= sync_speed_cycle)  // (Executed > NTSC/PAL hz 33ms)
   {
     previous_millis_sync = previous_millis_sync+sync_speed_cycle;    
+#ifdef CANVAS_SUPPORT
+    if(!fontMode && !canvasMode)
+#else
     if(!fontMode)
+#endif
        #ifndef KISS
        mspWriteRequest(MSP_ATTITUDE,0);
        #endif
@@ -329,7 +336,11 @@ void loop()
     #endif    
     #ifndef GPSOSD 
       #ifdef MSP_SPEED_MED
+        #ifdef CANVAS_SUPPORT
+        if(!fontMode && !canvasMode){
+        #else
         if(!fontMode){
+        #endif
           #ifndef KISS
           mspWriteRequest(MSP_ATTITUDE,0);
           #endif // KISS
@@ -451,7 +462,10 @@ void loop()
        #ifdef KISS
        Serial.write(0x20);
        #else     
-       mspWriteRequest(MSPcmdsend, 0); 
+         #ifdef CANVAS_SUPPORT
+         if (!canvasMode)
+           mspWriteRequest(MSPcmdsend, 0); 
+         #endif
        #endif // KISS
       #endif //GPSOSD
       #ifdef SKYTRACK
@@ -495,6 +509,28 @@ void loop()
       {
         displayConfigScreen();
       }
+#ifdef CANVAS_SUPPORT
+      else if (canvasMode)
+      {
+        // In canvas mode, we don't actively write the screen; just listen to MSP stream.
+        if (lastCanvas + CANVAS_TIMO < currentMillis) {
+          MAX7456_ClearScreen();
+          canvasMode = false;
+        }
+
+        // Place a small indicator for canvas mode to detect spurious 
+        // canvas requests.
+        // It should go away on the very first clear screen request,
+        // but may remain until next clear screen if the begin and
+        // the first clear request comes in back-to-back before the
+        // indicator is drawn.
+
+        if (canvasFirst) {
+          MAX7456_WriteString("*", (LINE01+01));
+          canvasFirst = false;
+        }
+      }
+#endif
       else
       {
         setMspRequests();

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -309,9 +309,11 @@ void loop()
 #else
     if(!fontMode)
 #endif
+    {
        #ifndef KISS
        mspWriteRequest(MSP_ATTITUDE,0);
        #endif
+    }
   }
 #endif //MSP_SPEED_HIGH
 
@@ -337,10 +339,11 @@ void loop()
     #ifndef GPSOSD 
       #ifdef MSP_SPEED_MED
         #ifdef CANVAS_SUPPORT
-        if(!fontMode && !canvasMode){
+        if(!fontMode && !canvasMode)
         #else
-        if(!fontMode){
+        if(!fontMode)
         #endif
+        {
           #ifndef KISS
           mspWriteRequest(MSP_ATTITUDE,0);
           #endif // KISS
@@ -464,8 +467,10 @@ void loop()
        #else     
          #ifdef CANVAS_SUPPORT
          if (!canvasMode)
-           mspWriteRequest(MSPcmdsend, 0); 
          #endif
+         {
+           mspWriteRequest(MSPcmdsend, 0); 
+         }
        #endif // KISS
       #endif //GPSOSD
       #ifdef SKYTRACK
@@ -483,10 +488,10 @@ void loop()
     if( allSec < INTRO_DELAY ){
       displayIntro();
       timer.lastCallSign=onTime-CALLSIGNINTERVAL;
-    }  
+    }
     else
     {
-    if(armed){
+      if(armed){
         previousarmedstatus=1;
         if (configMode==1)
           configExit();
@@ -520,10 +525,10 @@ void loop()
 
         // Place a small indicator for canvas mode to detect spurious 
         // canvas requests.
-        // It should go away on the very first clear screen request,
-        // but may remain until next clear screen if the begin and
-        // the first clear request comes in back-to-back before the
-        // indicator is drawn.
+        // In a normal situation, It should go away on the very first
+        // clear screen request, but may remain until next clear screen
+        // if the begin and the first clear request comes in back-to-back
+        // before the indicator is drawn.
 
         if (canvasFirst) {
           MAX7456_WriteString("*", (LINE01+01));

--- a/MW_OSD/Max7456.ino
+++ b/MW_OSD/Max7456.ino
@@ -343,19 +343,14 @@ void MAX7456_DrawScreen()
     MAX7456_Send(MAX7456ADD_DMDI, screen[xx]);
 
 #ifdef CANVAS_SUPPORT
-    // Don't erase in canvas mode
-    if (!canvasMode) {
+    if (!canvasMode) // Don't erase in canvas mode
+#endif
+    {
       screen[xx] = ' ';
     #ifdef INVERTED_CHAR_SUPPORT
       bitCLR(screenAttr, xx);
     #endif
     }
-#else
-    screen[xx] = ' ';
-  #ifdef INVERTED_CHAR_SUPPORT
-    bitCLR(screenAttr, xx);
-  #endif
-#endif
   }
 
   MAX7456_Send(MAX7456ADD_DMDI, END_string);

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -320,7 +320,9 @@ For sub-command 3 (draw string):
 2: row
 3: col
 4: attr (0=normal, 1=inverted)
-5...len-1: asciz string to draw (charset compat problem is ignored for now)
+5...len-1: string to draw
+           Zero prematurely terminates the string.
+           (Charset compat problem is ignored)
 */
 
     lastCanvas = millis();
@@ -339,13 +341,15 @@ For sub-command 3 (draw string):
       MAX7456_ClearScreen();
       break;
 
-    case 3: // Draw string at (row,col) with attribute
+    case 3: // Draw string at (row,col) with attribute (if supported)
       uint8_t canvasy = read8();
       uint8_t canvasx = read8();
       uint8_t canvasa = read8();
       for (int i = 5; i <= dataSize ; i++) {
         char canvasc[2];
         canvasc[0] = read8();
+        if (canvasc[0] == 0)
+          break;
         canvasc[1] = 0;
 #ifdef INVERTED_CHAR_SUPPORT
         MAX7456_WriteStringWithAttr(canvasc, canvasy * LINE + canvasx, canvasa);
@@ -859,12 +863,12 @@ void handleRawRC() {
   if(!waitStick)
   {
     if((MwRcData[PITCHSTICK]>MAXSTICK)&&(MwRcData[YAWSTICK]>MAXSTICK)&&(MwRcData[THROTTLESTICK]>MINSTICK)){
-    //if((MwRcData[PITCHSTICK]>MAXSTICK)&&(MwRcData[YAWSTICK]<MINSTICK)&&(MwRcData[THROTTLESTICK]>MINSTICK)){
 #ifdef CANVAS_SUPPORT
-      if (!configMode && (allSec > 5) && !armed && !canvasMode){
+      if (!configMode && (allSec > 5) && !armed && !canvasMode)
 #else
-      if (!configMode&&(allSec>5)&&!armed){
+      if (!configMode&&(allSec>5)&&!armed)
 #endif
+      {
           // Enter config mode using stick combination
           waitStick =  2;	// Sticks must return to center before continue!
           configMode = 1;

--- a/MW_OSD/bitarray.h
+++ b/MW_OSD/bitarray.h
@@ -1,0 +1,4 @@
+#define bitISSET(bits, off) (bits[(off)/8] & (1 << ((off) % 8)))
+#define bitISCLR(bits, off) (!bitISSET(bits, off))
+#define bitCLR(bits, off) { bits[(off)/8] &= ~(1 << ((off) % 8)); }
+#define bitSET(bits, off) { bits[(off)/8] |= ~(1 << ((off) % 8)); }

--- a/OTHER/DOCUMENTATION/Canvas_CMS.md
+++ b/OTHER/DOCUMENTATION/Canvas_CMS.md
@@ -1,0 +1,44 @@
+# CMS and Canvas Mode Guide
+
+Starting with Betaflight v3.1.0, flight controller (FC) will have a Configuration Menu System that operates across number of different display devices, such as FC-integrated OSD, external OSD with CANVAS extension, OLED display and radio telemetry screen. MWOSD supports the CMS with CANVAS extension.
+
+## FC configuration
+
+FC firmware must be built with `CMS` and `CANVAS` or equivalent options, and corresponding features should be turned on in configuration if they are controlled via features.
+
+## MWOSD configuration
+
+In `Config.h`, `CANVAS_SUPPORT` option must be enabled.
+
+`BETAFLIGHT` option will do this automatically (for v3.1.0 as of 2016-10-26).
+
+## Caveats
+
+### Dual CMS chaos
+
+When the FC-side CMS is enabled, you are going to have two CMS in your system; one in the FC and one in MWOSD. CMS invocation stick commands should be different, but you must be aware that these two CMS may not have the same navigational model and command system. You have to deal with this duality.
+
+One thing you absolutely have to avoid is to enter FC-side CMS invocation command while you are in the MWOSD CMS. While commands may work on MWOSD CMS, those commands are also handled in FC-side CMS and may produce unexpected results. (If you successfully exit the MWOSD CMS, you will end up in the OOS state explained below.)
+
+### OOS (Out-Of-Sync)
+
+MWOSD is very stable, and so is the canvas mode support. 
+
+However, since the canvas mode protocol is simplex from FC to MWOSD, CMS on FC and MWOSD may get out-of-sync, and your stick inputs may not be reflected to what is displayed on the screen.
+
+- Resetting or power cycling the MWOSD while the CMS is active will induce the OOS state at 120% probability.
+- Entering FC-side CMS invocation command while in the MWOSD-side CMS will very likely to end up in the OOS.
+- Other cases are not known yet.
+
+You can tell the out-of-sync state by:
+1. For the above mentioned reset case, the MWOSD will not get out of opening screen.
+2. You may see an asterisk character ('*') at upper left corner of your screen when this happens.
+3. You may also see cursor character move as you input navigational stick commands.
+4. Other erratic text displayed (not a screen full of random characters).
+
+There are numbers of ways to get out of this state.
+1. Enter a stick command that causes page redraw, such as menu back. (It is not a wise move to enter a stick command that causes item selection.)
+2. Blindly navigate to BACK or EXIT menu item and select it.
+3. Reset or power cycle your flight controller.
+
+Happy Flying!

--- a/OTHER/DOCUMENTATION/Canvas_CMS.md
+++ b/OTHER/DOCUMENTATION/Canvas_CMS.md
@@ -31,12 +31,14 @@ However, since the canvas mode protocol is simplex from FC to MWOSD, CMS on FC a
 - Other cases are not known yet.
 
 You can tell the out-of-sync state by:
+
 1. For the above mentioned reset case, the MWOSD will not get out of opening screen.
 2. You may see an asterisk character ('*') at upper left corner of your screen when this happens.
 3. You may also see cursor character move as you input navigational stick commands.
 4. Other erratic text displayed (not a screen full of random characters).
 
 There are numbers of ways to get out of this state.
+
 1. Enter a stick command that causes page redraw, such as menu back. (It is not a wise move to enter a stick command that causes item selection.)
 2. Blindly navigate to BACK or EXIT menu item and select it.
 3. Reset or power cycle your flight controller.


### PR DESCRIPTION
Canvas mode MSP messages are used by FC-side CMS (Configuration Menu System) to draw arbitral text on a screen.

The support is turned on by `CANVAS_SUPPORT` option, and is included as a part of `BETAFLIGHT` option.

This PR also include inverted character support, which is turned on by `INVERTED_CHAR_SUPPORT` option.

MSP canvas mode protocol:
byte: description
0: MSP_CANVAS
1: sub-command
   0: Enter/hold canvas mode
       Sender must periodically send the enter/hold message:
        FC may exist menu mode without notifying for many reasons,
        including manual reset or power off/cycle.
        We expect the FC to sustain canvasMode by sending non-exit
        message within CANVAS_TIMO while the menu mode is active.

   1: Exit canvas mode and resume normal OSD operation
   2: Clear canvas
   3: Draw string at (row,col) with attribute attr
        Automagically wraps to next row.

For sub-command 3 (draw string):
2: row
3: col
4: attr (0=normal, 1=inverted)
5...len-1: string to draw (charset compat problem is ignored)
