### PR TITLE
Rename MSP_CANVAS to MSP_DISPLAYPORT

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -759,7 +759,7 @@ uint16_t flyingTime=0;
 #define MSP_SERVO_CONF           120    //out message         Servo settings
 #define MSP_NAV_STATUS           121   //out message	     Returns navigation status
 
-#define MSP_CANVAS               182
+#define MSP_DISPLAYPORT          182
 
 #define MSP_CELLS                130   //out message         FrSky SPort Telemtry
 

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -302,16 +302,16 @@ void serialMSPCheck()
 #ifdef PROTOCOL_MSP
 
   #ifdef CANVAS_SUPPORT
-  if (cmdMSP == MSP_CANVAS) {
+  if (cmdMSP == MSP_DISPLAYPORT) {
     // Don't go into canvas mode when armed or in other special mode
     if (armed || fontMode || configMode)
         return;
 /*
-Notes on MSP_CANVAS protocol
+Notes on MSP_DISPLAYPORT protocol
 (should go into the protocol document... where is that?)
 
 byte: description
-0: MSP_CANVAS
+0: MSP_DISPLAYPORT
 1: sub-command
    0: Enter/hold canvas mode
        Sender must periodically send the enter/hold message:


### PR DESCRIPTION
Minor maintenance; to be coherent with BF3.1 naming.