### PR TITLE
Mavlink protocol improvements

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -159,7 +159,9 @@
 
 /******************** Mavlink settings *********************/
 //#define MAVLINKREQ                // Enable this for mavlink systems where the Mavlink data requires requesting. 
-
+#define MAV_SYS_ID 1                // System ID of MAV. 
+#define MAV_COM_ID 1                // Component ID of MAV.
+//#define MAV_ARMED                 // Forces OSD to be always armed (for when MAV does not send armed status in heartbeat).
 
 /******************** Serial MSP speed settings *********************/
 // Choose ONLY ONE option: increases speeds of serial update - but with impact to flight controller 

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -673,6 +673,10 @@
   #define ALWAYSARMED  // starts OSD in armed mode
 #endif
 
+#ifdef MAV_ARMED
+  #define ALWAYSARMED  // starts OSD in armed mode
+#endif
+
 #ifndef BAUDRATE 
   #ifdef PROTOCOL_MAVLINK 
     #define BAUDRATE 57600

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -177,7 +177,7 @@ uint16_t debug[4];   // int32_t ?...
 int8_t menudir;
 unsigned int allSec=0;
 unsigned int menuSec=0;
-uint8_t armedtimer=255;
+uint8_t armedtimer=30;
 uint16_t debugerror;
 uint16_t debugval=0;
 uint16_t cell_data[6]={0,0,0,0,0,0};
@@ -1359,7 +1359,7 @@ const PROGMEM char * const menu_on_off[] =
 
 #define MAVLINK_MSG_ID_HEARTBEAT 0
 #define MAVLINK_MSG_ID_HEARTBEAT_MAGIC 50
-#define AVLINK_MSG_ID_HEARTBEAT_LEN 9
+#define MAVLINK_MSG_ID_HEARTBEAT_LEN 9
 #define MAVLINK_MSG_ID_VFR_HUD 74
 #define MAVLINK_MSG_ID_VFR_HUD_MAGIC 20
 #define MAVLINK_MSG_ID_VFR_HUD_LEN 20
@@ -1463,10 +1463,8 @@ const PROGMEM char * const mav_mode_index[] =
 struct __mw_mav {
   uint8_t  message_cmd;
   uint8_t  message_length;
-  uint8_t  message_sysid;
   uint8_t  mode;
   uint8_t  sequence;
-  uint8_t  message_component;
   uint16_t serial_checksum;
   uint16_t tx_checksum;
   float    GPS_scaleLonDown;


### PR DESCRIPTION
Only process packets we use and where length is valid.
Only process packets for matching system and component i.d. default is 1
as per config.h

Outstanding:
verification of armed bit (can force in config.h)
verification of modes and sensor indicators