### PR TITLE
fix ltm altitude offset (issue #362)

### DIFF
--- a/MW_OSD/LTM.h
+++ b/MW_OSD/LTM.h
@@ -35,7 +35,6 @@ void GPS_reset_home_position() {
   if (GPS_fix && GPS_numSat >= MINSATFIX) {
     GPS_home[LAT] = GPS_latitude;
     GPS_home[LON] = GPS_longitude;
-    mw_ltm.GPS_altitude_home = GPS_altitude;
     GPS_calc_longitude_scaling(GPS_latitude);  //need an initial value for distance and bearing calc
     GPS_fix_HOME = 1;
   }


### PR DESCRIPTION
described this in issue #362, removing this line seems to have fixed the problem I was having with inav micro minimosd and ltm telemetry

leaving the line sets the offset to -2150 (my actual altitude according to google maps is somewhere around 1920 above sea level)