### PR TITLE
Fix for Innova power + refactor + restructure

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -13,8 +13,8 @@
 //#define KYLIN250PDB               // Uncomment this if using a Kylin 250 FPV PDB (Using A6 as VOLTAGEPIN)
 //#define AIRBOTMICRO               // Uncomment this if using an airbot MicroOSD
 //#define ANDROMEDA                 // Uncomment this if using an Andromeda (http://www.multiwiicopter.com/)
-//#define IMPULSERC_HELIX           // Uncomment this if using an ImpulseRC integrated OSD/VTX
-#define FFPV_INNOVA               // Uncomment this if using an ImpulseRC integrated OSD/VTX
+#define IMPULSERC_HELIX           // Uncomment this if using an ImpulseRC integrated OSD/VTX
+//#define FFPV_INNOVA               // Uncomment this if using an ImpulseRC integrated OSD/VTX
 
 // NOTE-some boards have swapped bat1/bat2 pins and alternative voltage measuring resistors
 // If having difficulties, first select default MINIMOSD as above, then use the following to correct: 

--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -13,8 +13,8 @@
 //#define KYLIN250PDB               // Uncomment this if using a Kylin 250 FPV PDB (Using A6 as VOLTAGEPIN)
 //#define AIRBOTMICRO               // Uncomment this if using an airbot MicroOSD
 //#define ANDROMEDA                 // Uncomment this if using an Andromeda (http://www.multiwiicopter.com/)
-#define IMPULSERC_HELIX           // Uncomment this if using an ImpulseRC integrated OSD/VTX
-//#define FFPV_INNOVA               // Uncomment this if using an ImpulseRC integrated OSD/VTX
+//#define IMPULSERC_HELIX           // Uncomment this if using an ImpulseRC integrated OSD/VTX
+#define FFPV_INNOVA               // Uncomment this if using an ImpulseRC integrated OSD/VTX
 
 // NOTE-some boards have swapped bat1/bat2 pins and alternative voltage measuring resistors
 // If having difficulties, first select default MINIMOSD as above, then use the following to correct: 

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -303,7 +303,7 @@
     MENU_PROFILE,
 #endif
 
-#define MENU_CONFIG_BASEFLIGHT_LEGACY \
+#define MENU_CONFIG_LEGACY \
     MENU_PID,      \
     MENU_RC,       \
     MENU_VOLTAGE,  \
@@ -328,7 +328,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined CLEANFLIGHT172
@@ -344,7 +344,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined FIXEDWING_BF
@@ -429,7 +429,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined (BASEFLIGHT20150327)
@@ -445,7 +445,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined (RACEFLIGHT)
@@ -461,7 +461,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined (MULTIWII_V24)
@@ -501,15 +501,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG \
-    MENU_PID,      \
-    MENU_RC,       \
-    MENU_VOLTAGE,  \
-    MENU_RSSI,     \
-    MENU_CURRENT,  \
-    MENU_DISPLAY,  \
-    MENU_ADVANCED, \
-    MENU_ALARMS,
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined (MULTIWII_V21)
@@ -525,15 +517,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG \
-    MENU_PID,      \
-    MENU_RC,       \
-    MENU_VOLTAGE,  \
-    MENU_RSSI,     \
-    MENU_CURRENT,  \
-    MENU_DISPLAY,  \
-    MENU_ADVANCED, \
-    MENU_ALARMS,
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined(TAULABS)
@@ -551,15 +535,7 @@
   #define USE_MENU_ADVANCED
   #define USE_MENU_ALARMS
 
-  #define MENU_CONFIG \
-    MENU_PID,      \
-    MENU_RC,       \
-    MENU_VOLTAGE,  \
-    MENU_RSSI,     \
-    MENU_CURRENT,  \
-    MENU_DISPLAY,  \
-    MENU_ADVANCED, \
-    MENU_ALARMS,
+  #define MENU_CONFIG MENU_CONFIG_LEGACY
 #endif
 
 #if defined(APM)

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -10,7 +10,7 @@
 // Display Debug screen display options
 //#define DEBUGMW            // Enable to display MSP debug values (assumes debug[x] values are not set elsewhere) 
 //#define DEBUG 4
-#define DEBUGDPOSRCDATA 264   // display RCDATA values at position X
+//#define DEBUGDPOSRCDATA 264   // display RCDATA values at position X
 //#define DEBUGDPOSANAL 84     // display sensor values at position X
 //#define DEBUGDPOSPWM 264     // display PWM values at position X
 //#define DEBUGDPOSVAL 40      // display debug values at position X
@@ -51,7 +51,7 @@
   #define VTX_RTC6705
   #define VTX_RC
   #define VTX_LED
-  #define MENU_VTX
+  #define USE_MENU_VTX
 #endif
 
 #ifdef FFPV_INNOVA
@@ -59,7 +59,7 @@
   #define VTX_RTC6705
   //#define VTX_RC    // Can be turned on, hard to use without VTX_LED
   //#define VTX_LED   // Needs VTXLED_* definitions in RTC6705.ino
-  #define MENU_VTX
+  #define USE_MENU_VTX
 #endif
 
 /********************  CONTROLLER rule definitions  **********************/
@@ -145,6 +145,33 @@
 //ENABLE_MSP_SAVE_ADVANCED - adds the code to read/write PROFILE+LOOPIME+PID CONTROLLER if supported
 //CORRECTLOOPTIME show looptime option in Adavanced tuning menu
 
+/*
+ * Flight Controller dependent definitions
+ */
+
+// Menu defs: USE_MENU_xxx decides which menu page to be configured
+//            MENU_CONFIG determines menu page order
+//            Note1: USE_MENU_STAT is mandatory
+//            Note2: MENU_STAT is automatically included in MENU_CONFIG.
+//            Note3: MENU_VTX is automatically included in MENU_CONFIG.
+//
+//  USE_MENU_STAT       STATISTICS
+//  USE_MENU_PID        PID CONFIG
+//  USE_MENU_RC         RC TUNING
+//  USE_MENU_RC_2       RC TUNING PAGE 2
+//  USE_MENU_VOLTAGE    VOLTAGE
+//  USE_MENU_RSSI       RSSI
+//  USE_MENU_CURRENT    CURRENT
+//  USE_MENU_DISPLAY    DISPLAY
+//  USE_MENU_ADVANCED   ADVANCED
+//  USE_MENU_ALARMS     ALARMS
+//  USE_MENU_PROFILE    PROFILE+PID CONTROLLER
+//  USE_MENU_FIXEDWING  FIXEDWING adjustments
+//  USE_MENU_SERVO      SERVO
+//  USE_MENU_GPS_TIME   GPS TIME
+//  USE_MENU_INFO       Guide for CMS
+//  USE_MENU_VTX        VTX, should be defined as a part of HARDWARE defs above.
+
 #if defined BETAFLIGHT2
   #define AMPERAGE_DIV 10
   #define CORRECT_MSP_CF2
@@ -152,18 +179,29 @@
   #define ENABLE_MSP_SAVE_ADVANCED
   #define ACROPLUS
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_RC_2     3       //RC TUNING PAGE 2
-  #define MENU_VOLTAGE  4       //VOLTAGE
-  #define MENU_RSSI     5       //RSSI
-  #define MENU_CURRENT  6       //CURRENT
-  #define MENU_DISPLAY  7       //DISPLAY
-  #define MENU_ADVANCED 8       //ADVANCED
-  #define MENU_ALARMS   9       //ALARMS
-  #define MENU_PROFILE  10      //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_RC_2
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+  #define USE_MENU_PROFILE
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_RC_2,     \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,   \
+    MENU_PROFILE,
 #endif
 
 #if defined BETAFLIGHT2
@@ -173,18 +211,29 @@
   #define ENABLE_MSP_SAVE_ADVANCED
   #define ACROPLUS
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_RC_2     3       //RC TUNING PAGE 2
-  #define MENU_VOLTAGE  4       //VOLTAGE
-  #define MENU_RSSI     5       //RSSI
-  #define MENU_CURRENT  6       //CURRENT
-  #define MENU_DISPLAY  7       //DISPLAY
-  #define MENU_ADVANCED 8       //ADVANCED
-  #define MENU_ALARMS   9       //ALARMS
-  #define MENU_PROFILE  10      //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_RC_2
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+  #define USE_MENU_PROFILE
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_RC_2,     \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,   \
+    MENU_PROFILE,
 #endif
 
 #if defined BETAFLIGHT31
@@ -193,22 +242,33 @@
   #define CORRECT_MENU_RCT2
   #define ENABLE_MSP_SAVE_ADVANCED
   #define ACROPLUS
-
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_RC_2     3       //RC TUNING PAGE 2
-  #define MENU_INFO     4       //RC TUNING PAGE 2
-  #define MENU_VOLTAGE  5       //VOLTAGE
-  #define MENU_RSSI     6       //RSSI
-  #define MENU_CURRENT  7       //CURRENT
-  #define MENU_DISPLAY  8       //DISPLAY
-  #define MENU_ADVANCED 9       //ADVANCED
-  #define MENU_ALARMS   10      //ALARMS
-  #define MENU_PROFILE  11      //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
-
   #define CANVAS_SUPPORT
+
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_RC_2
+  #define USE_MENU_INFO
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+  #define USE_MENU_PROFILE
+
+  #define MENU_CONFIG \
+    MENU_INFO,     \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_RC_2,     \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,   \
+    MENU_PROFILE,
 #endif
 
 #if defined CLEANFLIGHT190
@@ -218,49 +278,73 @@
   #define ENABLE_MSP_SAVE_ADVANCED
   #define CORRECTLOOPTIME
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_RC_2     3       //RC TUNING PAGE 2
-  #define MENU_VOLTAGE  4       //VOLTAGE
-  #define MENU_RSSI     5       //RSSI
-  #define MENU_CURRENT  6       //CURRENT
-  #define MENU_DISPLAY  7       //DISPLAY
-  #define MENU_ADVANCED 8       //ADVANCED
-  #define MENU_ALARMS   9       //ALARMS
-  #define MENU_PROFILE  10      //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_RC_2
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+  #define USE_MENU_PROFILE
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_RC_2,     \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,   \
+    MENU_PROFILE,
 #endif
+
+#define MENU_CONFIG_BASEFLIGHT_LEGACY \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 
 #if defined CLEANFLIGHT180
   #define AMPERAGE_DIV 10
   #define CORRECT_MSP_CF1
   #define CORRECT_MENU_RCT1
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
 #endif
 
 #if defined CLEANFLIGHT172
   #define AMPERAGE_DIV  10
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
 #endif
 
 #if defined FIXEDWING_BF
@@ -270,18 +354,29 @@
   #define CORRECT_MENU_RCT1
   #define ENABLE_MSP_SAVE_ADVANCED
 
-  #define MENU_STAT          0       //STATISTICS
-  #define MENU_PID           1       //PID CONFIG
-  #define MENU_RC            2       //RC TUNING
-  #define MENU_FIXEDWING     3       //FIXEDWING adjustments
-  #define MENU_VOLTAGE       4       //VOLTAGE
-  #define MENU_RSSI          5       //RSSI
-  #define MENU_CURRENT       6       //CURRENT
-  #define MENU_DISPLAY       7       //DISPLAY
-  #define MENU_ADVANCED      8       //ADVANCED
-  #define MENU_ALARMS        9       //ALARMS
-  #define MENU_PROFILE       10      //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_FIXEDWING
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+  #define USE_MENU_PROFILE
+
+  #define MENU_CONFIG \
+    MENU_PID,       \
+    MENU_RC,        \
+    MENU_FIXEDWING, \
+    MENU_VOLTAGE,   \
+    MENU_RSSI,      \
+    MENU_CURRENT,   \
+    MENU_DISPLAY,   \
+    MENU_ADVANCED,  \
+    MENU_ALARMS,    \
+    MENU_PROFILE,
 #endif
 
 #if defined FIXEDWING_BF_SERVO
@@ -291,19 +386,31 @@
   #define CORRECT_MENU_RCT1
   #define ENABLE_MSP_SAVE_ADVANCED
 
-  #define MENU_STAT          0       //STATISTICS
-  #define MENU_PID           1       //PID CONFIG
-  #define MENU_RC            2       //RC TUNING
-  #define MENU_SERVO         3       //SERVO
-  #define MENU_FIXEDWING     4       //FIXEDWING adjustments
-  #define MENU_VOLTAGE       5       //VOLTAGE
-  #define MENU_RSSI          6       //RSSI
-  #define MENU_CURRENT       7       //CURRENT
-  #define MENU_DISPLAY       8       //DISPLAY
-  #define MENU_ADVANCED      9       //ADVANCED
-  #define MENU_ALARMS        10       //ALARMS
-  #define MENU_PROFILE       11      //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_SERVO
+  #define USE_MENU_FIXEDWING
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+  #define USE_MENU_PROFILE
+
+  #define MENU_CONFIG \
+    MENU_PID,       \
+    MENU_RC,        \
+    MENU_SERVO,     \
+    MENU_FIXEDWING, \
+    MENU_VOLTAGE,   \
+    MENU_RSSI,      \
+    MENU_CURRENT,   \
+    MENU_DISPLAY,   \
+    MENU_ADVANCED,  \
+    MENU_ALARMS,    \
+    MENU_PROFILE,
 #endif
 
 #if defined BASEFLIGHT20150627
@@ -312,129 +419,189 @@
   #define CORRECT_MENU_RCT1
   #define ENABLE_MSP_SAVE_ADVANCED
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MENU_PROFILE  9       //PROFILE+PID CONTROLLER
-  #define MAXPAGE       MENU_PROFILE
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
 #endif
 
 #if defined (BASEFLIGHT20150327)
   #define AMPERAGE_DIV  10
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MAXPAGE MENU_ALARMS
+
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
 #endif
 
 #if defined (RACEFLIGHT)
   #define AMPERAGE_DIV  10
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_VOLTAGE  2       //VOLTAGE
-  #define MENU_RSSI     3       //RSSI
-  #define MENU_CURRENT  4       //CURRENT
-  #define MENU_DISPLAY  5       //DISPLAY
-  #define MENU_ADVANCED 6       //ADVANCED
-  #define MENU_ALARMS   7       //ALARMS
-  #define MAXPAGE MENU_ALARMS
+
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG MENU_CONFIG_BASEFLIGHT_LEGACY
 #endif
 
 #if defined (MULTIWII_V24)
   #define AMPERAGE_DIV  1
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_GPS_TIME 8       //GPS TIME
-  #define MENU_ALARMS   9       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_GPS_TIME
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_GPS_TIME, \
+    MENU_ALARMS,
 #endif
 
 #if defined (MULTIWII_V23)
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 #if defined (MULTIWII_V21)
   #define BOXNAMES              // required to support legacy protocol
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 #if defined(TAULABS)
   #define AMPERAGE_DIV  10
   #define HAS_ALARMS
   #define ACROPLUS
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_PID      1       //PID CONFIG
-  #define MENU_RC       2       //RC TUNING
-  #define MENU_VOLTAGE  3       //VOLTAGE
-  #define MENU_RSSI     4       //RSSI
-  #define MENU_CURRENT  5       //CURRENT
-  #define MENU_DISPLAY  6       //DISPLAY
-  #define MENU_ADVANCED 7       //ADVANCED
-  #define MENU_ALARMS   8       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+
+  #define USE_MENU_STAT
+  #define USE_MENU_PID
+  #define USE_MENU_RC
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_PID,      \
+    MENU_RC,       \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 #if defined(APM)
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_VOLTAGE  1       //VOLTAGE
-  #define MENU_RSSI     2       //RSSI
-  #define MENU_CURRENT  3       //CURRENT
-  #define MENU_DISPLAY  4       //DISPLAY
-  #define MENU_ADVANCED 5       //ADVANCED
-  #define MENU_ALARMS   6       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
   #define PROTOCOL_MAVLINK
   #define AMPERAGE_DIV 10
+
+  #define USE_MENU_STAT
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 #if defined(KISS)
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_VOLTAGE  1       //VOLTAGE
-  #define MENU_RSSI     2       //RSSI
-  #define MENU_CURRENT  3       //CURRENT
-  #define MENU_DISPLAY  4       //DISPLAY
-  #define MENU_ADVANCED 5       //ADVANCED
-  #define MENU_ALARMS   6       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
   #define PROTOCOL_KISS
   #define AMPERAGE_DIV 10
+
+  #define USE_MENU_STAT
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 #ifdef SKYTRACK
@@ -443,9 +610,12 @@
   #undef  ALARM_SATS
   #undef  ALARM_GPS
   #undef  OSD_SWITCH_RC
-  #define MENU_STAT  0           //STATISTICS
-  #define MAXPAGE MENU_STAT
+
   #define PROTOCOL_SKYTRACK
+
+  #define USE_MENU_STAT
+  #define MENU_CONFIG // empty
+  
 #endif
 
 #ifdef NOCONTROLLER
@@ -454,9 +624,11 @@
   #undef  ALARM_SATS
   #undef  ALARM_GPS
   #undef  OSD_SWITCH_RC
+
   #define HIDEARMEDSTATUS
-  #define MENU_STAT  0           //STATISTICS
-  #define MAXPAGE MENU_STAT
+
+  #define USE_MENU_STAT
+  #define MENU_CONFIG // empty
 #endif
 
 #if defined GPSOSD_UBLOX
@@ -514,38 +686,46 @@
   #define HIDEARMEDSTATUS
   #define ALARM_GPS 5
 
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_VOLTAGE  1       //VOLTAGE
-  #define MENU_RSSI     2       //RSSI
-  #define MENU_CURRENT  3       //CURRENT
-  #define MENU_DISPLAY  4       //DISPLAY
-  #define MENU_ADVANCED 5       //ADVANCED
-  #define MENU_ALARMS   6       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+  #define USE_MENU_STAT
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 // Flight Controller Software types to be added before here...
 
-#ifndef MAXPAGE
+#ifndef USE_MENU_STAT
   #define INFO_CONTROLLER 0
-  #define MENU_STAT     0       //STATISTICS
-  #define MENU_VOLTAGE  1       //VOLTAGE
-  #define MENU_RSSI     2       //RSSI
-  #define MENU_CURRENT  3       //CURRENT
-  #define MENU_DISPLAY  4       //DISPLAY
-  #define MENU_ADVANCED 5       //ADVANCED
-  #define MENU_ALARMS   6       //ALARMS
-  #define MAXPAGE       MENU_ALARMS
+
+  #define USE_MENU_STAT
+  #define USE_MENU_VOLTAGE
+  #define USE_MENU_RSSI
+  #define USE_MENU_CURRENT
+  #define USE_MENU_DISPLAY
+  #define USE_MENU_ADVANCED
+  #define USE_MENU_ALARMS
+
+  #define MENU_CONFIG \
+    MENU_VOLTAGE,  \
+    MENU_RSSI,     \
+    MENU_CURRENT,  \
+    MENU_DISPLAY,  \
+    MENU_ADVANCED, \
+    MENU_ALARMS,
 #endif
 
 // ALL controller type MENUS must go before here. This area is to add extra menus for hardware
-
-#ifdef VTX_RTC6705
-  const uint8_t MENU_vtx_tmp = MAXPAGE+1;
-  #define MENU_VTX MENU_vtx_tmp
-  #undef  MAXPAGE
-  #define MAXPAGE MENU_VTX 
-#endif
 
 #ifdef HAS_ALARMS
   #define MAX_ALARM_LEN 30

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -225,13 +225,13 @@ struct __cfgpa {
 }
 cfgpa;
 
-#ifdef MENU_SERVO  
+#ifdef USE_MENU_SERVO  
 #define MAX_SERVOS 8
 struct __servo {
     uint16_t settings[5][MAX_SERVOS];
 }
 servo;
-#endif //MENU_SERVO  
+#endif //USE_MENU_SERVO  
 
 
 uint16_t debug[4];   // int32_t ?...
@@ -269,8 +269,9 @@ uint8_t screenlayout=0;
 uint8_t oldscreenlayout=0;
 uint8_t ROW=10;
 uint8_t COL=3;
-int8_t configPage=1;
-int8_t previousconfigPage=1;
+int8_t configPage;
+int8_t configIndex;
+int8_t previousConfigIndex=1;
 uint8_t configMode=0;
 uint8_t fontMode = 0;
 uint8_t fontData[54];
@@ -1006,160 +1007,6 @@ const char configMsgMWII[] PROGMEM = "USE FC";
 // For APSTATUS
 
 // For Config pages
-//-----------------------------------------------------------Page0
-const char configMsg00[] PROGMEM = "STATISTICS";
-const char configMsg01[] PROGMEM = "FLY TIME";
-const char configMsg02[] PROGMEM = "TOT DISTANCE";
-const char configMsg03[] PROGMEM = "MAX DISTANCE";
-const char configMsg04[] PROGMEM = "MAX ALTITUDE";
-const char configMsg05[] PROGMEM = "MAX SPEED";
-const char configMsg06[] PROGMEM = "MAH USED";
-const char configMsg07[] PROGMEM = "MAX AMPS";
-//-----------------------------------------------------------Page1
-const char configMsg10[] PROGMEM = "PID CONFIG";
-
-#ifndef USE_MSP_PIDNAMES
-const char configMsg11[] PROGMEM = "ROLL";
-const char configMsg12[] PROGMEM = "PITCH";
-const char configMsg13[] PROGMEM = "YAW";
-const char configMsg14[] PROGMEM = "ALT";
-const char configMsg15[] PROGMEM = "GPS";
-const char configMsg16[] PROGMEM = "LEVEL";
-const char configMsg17[] PROGMEM = "MAG";
-#ifdef MENU_PID_VEL
-const char configMsg18[] PROGMEM = "Z_VEL";
-#endif
-#endif /* !USE_MSP_PIDNAMES */
-
-//-----------------------------------------------------------Page2
-const char configMsg20[] PROGMEM = "RC TUNING";
-const char configMsg21[] PROGMEM = "RC RATE";
-const char configMsg22[] PROGMEM = "RC EXPO";
-const char configMsg23[] PROGMEM = "ROLL PITCH RATE";
-const char configMsg24[] PROGMEM = "YAW RATE";
-const char configMsg25[] PROGMEM = "TPA";
-const char configMsg26[] PROGMEM = "THROTTLE MID";
-const char configMsg27[] PROGMEM = "THROTTLE EXPO";
-#if defined CORRECT_MENU_RCT1
-  const char configMsg23a[] PROGMEM = "ROLL RATE";
-  const char configMsg23b[] PROGMEM = "PITCH RATE";
-#endif
-#if defined CORRECT_MENU_RCT2
-  const char configMsg23a[] PROGMEM = "ROLL RATE";
-  const char configMsg23b[] PROGMEM = "PITCH RATE";
-#endif
-//-----------------------------------------------------------Page3
-const char configMsg30[] PROGMEM = "VOLTAGE";
-const char configMsg31[] PROGMEM = "DISPLAY MAIN VOLTS";
-const char configMsg32[] PROGMEM = "ADJUST VOLTS";
-const char configMsg33[] PROGMEM = "MAIN VOLTS ALARM";
-const char configMsg34[] PROGMEM = "DISPLAY VID VOLTS";
-const char configMsg35[] PROGMEM = "ADJUST VOLTS";
-const char configMsg36[] PROGMEM = "CELLS";
-const char configMsg37[] PROGMEM = "USE FC";
-
-//-----------------------------------------------------------Page4
-const char configMsg40[] PROGMEM = "RSSI";
-const char configMsg42[] PROGMEM = "DISPLAY RSSI";
-const char configMsg43[] PROGMEM = "SET RSSI";
-const char configMsg44[] PROGMEM = "SET RSSI MAX";
-const char configMsg45[] PROGMEM = "SET RSSI MIN";
-const char configMsg46[] PROGMEM = "USE PWM";
-
-//-----------------------------------------------------------Page5
-const char configMsg50[] PROGMEM = "CURRENT";
-const char configMsg51[] PROGMEM = "DISPLAY AMPS";
-const char configMsg52[] PROGMEM = "DISPLAY MAH";
-const char configMsg53[] PROGMEM = "USE VIRTUAL SENSOR";
-const char configMsg54[] PROGMEM = "ADJUST AMPS";
-const char configMsg55[] PROGMEM = "ADJUST ZERO";
-//-----------------------------------------------------------Page6
-const char configMsg60[] PROGMEM = "DISPLAY";
-const char configMsg61[] PROGMEM = "HORIZON";
-const char configMsg62[] PROGMEM = "SIDE BARS";
-const char configMsg63[] PROGMEM = "SCROLLING BARS";
-const char configMsg64[] PROGMEM = "THROTTLE";
-const char configMsg65[] PROGMEM = "GPS COORDS";
-const char configMsg66[] PROGMEM = "SENSORS";
-const char configMsg67[] PROGMEM = "GIMBAL";
-const char configMsg68[] PROGMEM = "MAP MODE";
-//-----------------------------------------------------------Page7
-const char configMsg70[]  PROGMEM = "ADVANCED";
-const char configMsg71[]  PROGMEM = "UNITS";
-const char configMsg710[] PROGMEM = "MET";
-const char configMsg711[] PROGMEM = "IMP";
-const char configMsg73[]  PROGMEM = "V REF";
-const char configMsg730[] PROGMEM = "5V";
-const char configMsg731[] PROGMEM = "1.1V";
-const char configMsg74[]  PROGMEM = "DEBUG";
-const char configMsg75[]  PROGMEM = "MAG CAL";
-const char configMsg76[]  PROGMEM = "OSD TX CH";
-const char configMsg77[]  PROGMEM = "THROTTLE PWM";
-//-----------------------------------------------------------Page8
-const char configMsg80[] PROGMEM = "GPS TIME";
-const char configMsg81[] PROGMEM = "DISPLAY";
-const char configMsg82[] PROGMEM = "TZ FORWARD";
-const char configMsg83[] PROGMEM = "TZ ADJUST";
-//-----------------------------------------------------------Page9
-const char configMsg90[] PROGMEM = "ALARMS";
-const char configMsg91[] PROGMEM = "DISTANCE X100";
-const char configMsg92[] PROGMEM = "ALTITUDE X10";
-const char configMsg93[] PROGMEM = "SPEED";
-const char configMsg94[] PROGMEM = "TIMER";
-const char configMsg95[] PROGMEM = "MAH X100";
-const char configMsg96[] PROGMEM = "AMPS";
-const char configMsg97[] PROGMEM = "TEXT ALARMS";
-
-//-----------------------------------------------------------Page10
-const char configMsg100[] PROGMEM = "ADVANCE TUNING";
-const char configMsg101[] PROGMEM = "PROFILE";
-const char configMsg102[] PROGMEM = "PID CONTROLLER";
-const char configMsg103[] PROGMEM = "LOOPTIME";
-//-----------------------------------------------------------BF FIXEDWING Page
-const char configMsg110[] PROGMEM = "FIXEDWING";
-const char configMsg111[] PROGMEM = "MAX CORRECT";
-const char configMsg112[] PROGMEM = "RUDDER";
-const char configMsg113[] PROGMEM = "MAX CLIMB";
-const char configMsg114[] PROGMEM = "MAX DIVE";
-const char configMsg115[] PROGMEM = "THR CLIMB";
-const char configMsg116[] PROGMEM = "THR CRUISE";
-const char configMsg117[] PROGMEM = "THR IDLE";
-const char configMsg118[] PROGMEM = "RTH ALT";
-//-----------------------------------------------------------SERVO Page
-const char configMsg120[] PROGMEM = "SERVOS";
-const char configMsg121[] PROGMEM = "S0";
-const char configMsg122[] PROGMEM = "S1";
-const char configMsg123[] PROGMEM = "S2";
-const char configMsg124[] PROGMEM = "S3";
-const char configMsg125[] PROGMEM = "S4";
-const char configMsg126[] PROGMEM = "S5";
-const char configMsg127[] PROGMEM = "S6";
-const char configMsg128[] PROGMEM = "S7";
-//-----------------------------------------------------------RC TUNING Page 2
-const char configMsg130[] PROGMEM = "RC TUNING 2";
-const char configMsg131[] PROGMEM = "TPA BREAKPOINT";
-const char configMsg132[] PROGMEM = "YAW RC EXPO";
-//-----------------------------------------------------------INFO Page
-const char configMsg140[] PROGMEM = "ACCESS ALL SETTINGS";
-const char configMsg141[] PROGMEM = "TX  :THRT MIDDLE";
-const char configMsg142[] PROGMEM = "    +YAW LEFT";
-const char configMsg143[] PROGMEM = "    +PITCH FULL";
-const char configMsg144[] PROGMEM = " ";
-const char configMsg145[] PROGMEM = "F3 CONTROLLERS ONLY";
-//-----------------------------------------------------------VTX Page
-const char configMsg150[] PROGMEM = "VTX";
-const char configMsg151[] PROGMEM = "POWER";
-const char configMsg152[] PROGMEM = "BAND";
-const char configMsg153[] PROGMEM = "CHANNEL";
-const char configMsg154[] PROGMEM = "";
-const char configMsg1510[] PROGMEM = "25";
-const char configMsg1511[] PROGMEM = "200";
-const char configMsg1512[] PROGMEM = "500";
-const char configMsg1520[] PROGMEM = "BOSCAM A";
-const char configMsg1521[] PROGMEM = "BOSCAM B";
-const char configMsg1522[] PROGMEM = "BOSCAM E";
-const char configMsg1523[] PROGMEM = "FATSHARK";
-const char configMsg1524[] PROGMEM = "RACE";
 
 // POSITION OF EACH CHARACTER OR LOGO IN THE MAX7456
 const unsigned char speedUnitAdd[2] ={
@@ -1195,19 +1042,466 @@ const unsigned char UnitsIcon[8]={
 #define REQ_MSP_FW_CONFIG      (1L<<20) 
 #define REQ_MSP_PIDNAMES       (1L<<21)
 #define REQ_MSP_SERVO_CONF     (1L<<22)
+
 // Menu selections
+
+typedef enum {
+#ifdef USE_MENU_STAT
+  MENU_STAT = 0,  // STATISTICS
+#endif
+#ifdef USE_MENU_PID
+  MENU_PID,       // PID CONFIG
+#endif
+#ifdef USE_MENU_RC
+  MENU_RC,        // RC TUNING
+#endif
+#ifdef USE_MENU_RC_2
+  MENU_RC_2,      // RC TUNING PAGE 2
+#endif
+#ifdef USE_MENU_INFO
+  MENU_INFO,      // BF CMS guide
+#endif
+#ifdef USE_MENU_VOLTAGE
+  MENU_VOLTAGE,   // VOLTAGE
+#endif
+#ifdef USE_MENU_RSSI
+  MENU_RSSI,      // RSSI
+#endif
+#ifdef USE_MENU_CURRENT
+  MENU_CURRENT,   // CURRENT
+#endif
+#ifdef USE_MENU_DISPLAY
+  MENU_DISPLAY,   // DISPLAY
+#endif
+#ifdef USE_MENU_ADVANCED
+  MENU_ADVANCED,  // ADVANCED
+#endif
+#ifdef USE_MENU_ALARMS
+  MENU_ALARMS,    // ALARMS
+#endif
+#ifdef USE_MENU_PROFILE
+  MENU_PROFILE,   // PROFILE+PID CONTROLLER
+#endif
+#ifdef USE_MENU_FIXEDWING
+  MENU_FIXEDWING, //FIXEDWING adjustments
+#endif
+#ifdef USE_MENU_SERVO
+  MENU_SERVO,    //FIXEDWING adjustments
+#endif
+#ifdef USE_MENU_GPS_TIME
+  MENU_GPS_TIME, //GPS time
+#endif
+#ifdef USE_MENU_VTX
+  MENU_VTX,      // VTX
+#endif
+  MENU_LAST,
+  MAXPAGE = MENU_VTX - 1
+} menuId_e;
+
+uint8_t menuConfig[] = {
+#ifdef USE_MENU_STAT
+    MENU_STAT,
+#endif
+#ifdef USE_MENU_VTX
+    MENU_VTX,
+#endif
+    MENU_CONFIG
+};
+
+// Menu strings
+
+
+//-----------------------------------------------------------Page0
+const char configMsg00[] PROGMEM = "STATISTICS";
+const char configMsg01[] PROGMEM = "FLY TIME";
+const char configMsg02[] PROGMEM = "TOT DISTANCE";
+const char configMsg03[] PROGMEM = "MAX DISTANCE";
+const char configMsg04[] PROGMEM = "MAX ALTITUDE";
+const char configMsg05[] PROGMEM = "MAX SPEED";
+const char configMsg06[] PROGMEM = "MAH USED";
+const char configMsg07[] PROGMEM = "MAX AMPS";
+
+const PROGMEM char * const menu_stats_item[] =
+{   
+  configMsg01,
+  configMsg02,
+  configMsg03,
+  configMsg04,
+  configMsg05,
+  configMsg06,
+  configMsg07,
+};
+
+//-----------------------------------------------------------Page1
+#ifdef USE_MENU_PID
+const char configMsg10[] PROGMEM = "PID CONFIG";
+
+#ifndef USE_MSP_PIDNAMES
+const char configMsg11[] PROGMEM = "ROLL";
+const char configMsg12[] PROGMEM = "PITCH";
+const char configMsg13[] PROGMEM = "YAW";
+const char configMsg14[] PROGMEM = "ALT";
+const char configMsg15[] PROGMEM = "GPS";
+const char configMsg16[] PROGMEM = "LEVEL";
+const char configMsg17[] PROGMEM = "MAG";
+# ifdef MENU_PID_VEL
+const char configMsg18[] PROGMEM = "Z_VEL";
+# endif
+#endif /* !USE_MSP_PIDNAMES */
+
+#ifdef USE_MSP_PIDNAMES
+
+# define PIDNAME_BUFSIZE  8
+# ifdef MENU_PID_VEL
+#  define PIDNAME_NUMITEMS 8
+# else
+#  define PIDNAME_NUMITEMS 7
+# endif
+
+char menu_pid[PIDNAME_NUMITEMS][PIDNAME_BUFSIZE];
+
+#else /* USE_MSP_PIDNAMES */
+const PROGMEM char * const menu_pid[] = 
+{   
+  configMsg11,
+  configMsg12,
+  configMsg13,
+  configMsg14,
+  configMsg15,
+  configMsg16,
+  configMsg17,
+# ifdef MENU_PID_VEL
+  configMsg18,
+# endif
+};
+#endif // USE_MSP_PIDNAMES
+
+#endif // USE_MENU_PID
+
+//-----------------------------------------------------------Page2
+#ifdef USE_MENU_RC
+const char configMsg20[] PROGMEM = "RC TUNING";
+const char configMsg21[] PROGMEM = "RC RATE";
+const char configMsg22[] PROGMEM = "RC EXPO";
+const char configMsg23[] PROGMEM = "ROLL PITCH RATE";
+const char configMsg24[] PROGMEM = "YAW RATE";
+const char configMsg25[] PROGMEM = "TPA";
+const char configMsg26[] PROGMEM = "THROTTLE MID";
+const char configMsg27[] PROGMEM = "THROTTLE EXPO";
+
+#if defined CORRECT_MENU_RCT1
+  const char configMsg23a[] PROGMEM = "ROLL RATE";
+  const char configMsg23b[] PROGMEM = "PITCH RATE";
+#endif
+#if defined CORRECT_MENU_RCT2
+  const char configMsg23a[] PROGMEM = "ROLL RATE";
+  const char configMsg23b[] PROGMEM = "PITCH RATE";
+#endif
+
+const PROGMEM char * const menu_rc[] = 
+{   
+  #if defined CORRECT_MENU_RCT2
+    configMsg21,
+    configMsg22,
+    configMsg23a,
+    configMsg23b,
+    configMsg24,
+    configMsg25,
+    configMsg26,
+    configMsg27,
+  #elif defined CORRECT_MENU_RCT1 
+    configMsg21,
+    configMsg22,
+    configMsg23a,
+    configMsg23b,
+    configMsg24,
+    configMsg25,
+    configMsg26,
+    configMsg27,
+  #else //BF original / Cleanflight original / multiwii
+    configMsg21,
+    configMsg22,
+    configMsg23,
+    configMsg24,
+    configMsg25,
+    configMsg26,
+    configMsg27,
+  #endif
+
+};
+#endif
+
+//-----------------------------------------------------------Page3
+#ifdef USE_MENU_VOLTAGE
+const char configMsg30[] PROGMEM = "VOLTAGE";
+const char configMsg31[] PROGMEM = "DISPLAY MAIN VOLTS";
+const char configMsg32[] PROGMEM = "ADJUST VOLTS";
+const char configMsg33[] PROGMEM = "MAIN VOLTS ALARM";
+const char configMsg34[] PROGMEM = "DISPLAY VID VOLTS";
+const char configMsg35[] PROGMEM = "ADJUST VOLTS";
+const char configMsg36[] PROGMEM = "CELLS";
+const char configMsg37[] PROGMEM = "USE FC";
+
+const PROGMEM char * const menu_bat[] = 
+{   
+  configMsg31,
+  configMsg32,
+  configMsg33,
+  configMsg34,
+  configMsg32,
+  configMsg36,
+  configMsgMWII,
+};
+#endif
+
+//-----------------------------------------------------------Page4
+#ifdef USE_MENU_RSSI
+const char configMsg40[] PROGMEM = "RSSI";
+const char configMsg42[] PROGMEM = "DISPLAY RSSI";
+const char configMsg43[] PROGMEM = "SET RSSI";
+const char configMsg44[] PROGMEM = "SET RSSI MAX";
+const char configMsg45[] PROGMEM = "SET RSSI MIN";
+const char configMsg46[] PROGMEM = "USE PWM";
+
+const PROGMEM char * const menu_rssi[] = 
+{   
+  configMsg42,
+  configMsg43,
+  configMsgMWII,
+  configMsg46,
+  configMsg44,
+  configMsg45,
+};
+#endif
+
+//-----------------------------------------------------------Page5
+#ifdef USE_MENU_CURRENT
+const char configMsg50[] PROGMEM = "CURRENT";
+const char configMsg51[] PROGMEM = "DISPLAY AMPS";
+const char configMsg52[] PROGMEM = "DISPLAY MAH";
+const char configMsg53[] PROGMEM = "USE VIRTUAL SENSOR";
+const char configMsg54[] PROGMEM = "ADJUST AMPS";
+const char configMsg55[] PROGMEM = "ADJUST ZERO";
+
+const PROGMEM char * const menu_amps[] = 
+{   
+  configMsg51,
+  configMsg52,
+  configMsg53,
+  configMsg54,
+  configMsg55,
+};
+#endif
+
+//-----------------------------------------------------------Page6
+#ifdef USE_MENU_DISPLAY
+const char configMsg60[] PROGMEM = "DISPLAY";
+const char configMsg61[] PROGMEM = "HORIZON";
+const char configMsg62[] PROGMEM = "SIDE BARS";
+const char configMsg63[] PROGMEM = "SCROLLING BARS";
+const char configMsg64[] PROGMEM = "THROTTLE";
+const char configMsg65[] PROGMEM = "GPS COORDS";
+const char configMsg66[] PROGMEM = "SENSORS";
+const char configMsg67[] PROGMEM = "GIMBAL";
+const char configMsg68[] PROGMEM = "MAP MODE";
+
+const PROGMEM char * const menu_display[] = 
+{   
+  configMsg61,
+  configMsg62,
+  configMsg63,
+  configMsg64,
+  configMsg65,
+  configMsg66,
+  configMsg67,
+  configMsg68,
+};
+#endif
+
+//-----------------------------------------------------------Page7
+#ifdef USE_MENU_ADVANCED
+const char configMsg70[]  PROGMEM = "ADVANCED";
+const char configMsg71[]  PROGMEM = "UNITS";
+const char configMsg710[] PROGMEM = "MET";
+const char configMsg711[] PROGMEM = "IMP";
+const char configMsg73[]  PROGMEM = "V REF";
+const char configMsg730[] PROGMEM = "5V";
+const char configMsg731[] PROGMEM = "1.1V";
+const char configMsg74[]  PROGMEM = "DEBUG";
+const char configMsg75[]  PROGMEM = "MAG CAL";
+const char configMsg76[]  PROGMEM = "OSD TX CH";
+const char configMsg77[]  PROGMEM = "THROTTLE PWM";
+
 const PROGMEM char * const menu_choice_unit[] =
 {   
   configMsg710,
   configMsg711,
 };
+
 const PROGMEM char * const menu_choice_ref[] =
 {   
   configMsg731,
   configMsg730,
 };
 
-#ifdef MENU_VTX
+const PROGMEM char * const menu_advanced[] = 
+{   
+  configMsg71,
+  configMsg73,
+  configMsg74,
+  configMsg75,
+  configMsg76,
+  configMsg77,
+};
+#endif
+
+//-----------------------------------------------------------Page8
+#ifdef USE_MENU_GPS_TIME
+const char configMsg80[] PROGMEM = "GPS TIME";
+const char configMsg81[] PROGMEM = "DISPLAY";
+const char configMsg82[] PROGMEM = "TZ FORWARD";
+const char configMsg83[] PROGMEM = "TZ ADJUST";
+const PROGMEM char * const menu_gps_time[] = 
+{   
+  configMsg81,
+  configMsg82,
+  configMsg83,
+};
+#endif
+
+//-----------------------------------------------------------Page9
+#ifdef USE_MENU_ALARMS
+const char configMsg90[] PROGMEM = "ALARMS";
+const char configMsg91[] PROGMEM = "DISTANCE X100";
+const char configMsg92[] PROGMEM = "ALTITUDE X10";
+const char configMsg93[] PROGMEM = "SPEED";
+const char configMsg94[] PROGMEM = "TIMER";
+const char configMsg95[] PROGMEM = "MAH X100";
+const char configMsg96[] PROGMEM = "AMPS";
+const char configMsg97[] PROGMEM = "TEXT ALARMS";
+
+const PROGMEM char * const menu_alarm_item[] = 
+{   
+  configMsg91,
+  configMsg92,
+  configMsg93,
+  configMsg94,
+  configMsg95,
+  configMsg96,
+  configMsg97,
+};
+#endif
+
+//-----------------------------------------------------------Page10
+#ifdef USE_MENU_PROFILE
+const char configMsg100[] PROGMEM = "ADVANCE TUNING";
+const char configMsg101[] PROGMEM = "PROFILE";
+const char configMsg102[] PROGMEM = "PID CONTROLLER";
+const char configMsg103[] PROGMEM = "LOOPTIME";
+
+const PROGMEM char * const menu_profile[] = 
+{   
+  configMsg101,
+  configMsg102,
+  configMsg103,
+};
+#endif
+
+//-----------------------------------------------------------BF FIXEDWING Page
+#ifdef USE_MENU_FIXEDWING
+const char configMsg110[] PROGMEM = "FIXEDWING";
+const char configMsg111[] PROGMEM = "MAX CORRECT";
+const char configMsg112[] PROGMEM = "RUDDER";
+const char configMsg113[] PROGMEM = "MAX CLIMB";
+const char configMsg114[] PROGMEM = "MAX DIVE";
+const char configMsg115[] PROGMEM = "THR CLIMB";
+const char configMsg116[] PROGMEM = "THR CRUISE";
+const char configMsg117[] PROGMEM = "THR IDLE";
+const char configMsg118[] PROGMEM = "RTH ALT";
+
+const PROGMEM char * const menu_fixedwing_bf[] = 
+{   
+  configMsg111,
+  configMsg112,
+  configMsg113,
+  configMsg114,
+  configMsg115,
+  configMsg116,
+  configMsg117,
+  configMsg118,
+};
+#endif
+
+//-----------------------------------------------------------SERVO Page
+#ifdef USE_MENU_SERVO
+const char configMsg120[] PROGMEM = "SERVOS";
+const char configMsg121[] PROGMEM = "S0";
+const char configMsg122[] PROGMEM = "S1";
+const char configMsg123[] PROGMEM = "S2";
+const char configMsg124[] PROGMEM = "S3";
+const char configMsg125[] PROGMEM = "S4";
+const char configMsg126[] PROGMEM = "S5";
+const char configMsg127[] PROGMEM = "S6";
+const char configMsg128[] PROGMEM = "S7";
+const PROGMEM char * const menu_servo[] = 
+{   
+  configMsg121,
+  configMsg122,
+  configMsg123,
+  configMsg124,
+  configMsg125,
+  configMsg126,
+  configMsg127,
+  configMsg128,
+};
+#endif
+
+//-----------------------------------------------------------RC TUNING Page 2
+#ifdef USE_MENU_RC_2
+const char configMsg130[] PROGMEM = "RC TUNING 2";
+const char configMsg131[] PROGMEM = "TPA BREAKPOINT";
+const char configMsg132[] PROGMEM = "YAW RC EXPO";
+const PROGMEM char * const menu_rc_2[] = 
+{   
+  configMsg131,
+  configMsg132,
+};
+#endif
+
+//-----------------------------------------------------------INFO Page
+#ifdef USE_MENU_INFO
+const char configMsg140[] PROGMEM = "FC-SIDE MENU INVOCATION";
+const char configMsg141[] PROGMEM = "TX  :THRT MIDDLE";
+const char configMsg142[] PROGMEM = "    +YAW LEFT";
+const char configMsg143[] PROGMEM = "    +PITCH FULL";
+const char configMsg144[] PROGMEM = " ";
+const char configMsg145[] PROGMEM = "BF3.1 AND LATER ONLY";
+const PROGMEM char * const menu_info[] = 
+{   
+  configMsg141,
+  configMsg142,
+  configMsg143,
+  configMsg144,
+  configMsg145,
+};
+#endif
+
+//-----------------------------------------------------------VTX Page
+#ifdef USE_MENU_VTX
+const char configMsg150[] PROGMEM = "VTX";
+const char configMsg151[] PROGMEM = "POWER";
+const char configMsg152[] PROGMEM = "BAND";
+const char configMsg153[] PROGMEM = "CHANNEL";
+const char configMsg154[] PROGMEM = "";
+const char configMsg1510[] PROGMEM = "25";
+const char configMsg1511[] PROGMEM = "200";
+const char configMsg1512[] PROGMEM = "500";
+const char configMsg1520[] PROGMEM = "BOSCAM A";
+const char configMsg1521[] PROGMEM = "BOSCAM B";
+const char configMsg1522[] PROGMEM = "BOSCAM E";
+const char configMsg1523[] PROGMEM = "FATSHARK";
+const char configMsg1524[] PROGMEM = "RACE";
+
   #ifdef VTX_REGION_UNRESTRICTED
   // Menu selections
   const PROGMEM char * const vtxPowerNames[] =
@@ -1252,245 +1546,56 @@ const PROGMEM char * const menu_vtx[] =
   configMsg153,
   configMsg154,
 };
-
 #endif //MENU_VTX
-
-// Menu
-//PROGMEM const char *menu_stats_item[] =
-const PROGMEM char * const menu_stats_item[] =
-{   
-  configMsg01,
-  configMsg02,
-  configMsg03,
-  configMsg04,
-  configMsg05,
-  configMsg06,
-  configMsg07,
-};
-
-#ifdef USE_MSP_PIDNAMES
-
-#define PIDNAME_BUFSIZE  8
-#ifdef MENU_PID_VEL
-#define PIDNAME_NUMITEMS 8
-#else
-#define PIDNAME_NUMITEMS 7
-#endif
-
-char menu_pid[PIDNAME_NUMITEMS][PIDNAME_BUFSIZE];
-
-#else /* USE_MSP_PIDNAMES */
-const PROGMEM char * const menu_pid[] = 
-{   
-  configMsg11,
-  configMsg12,
-  configMsg13,
-  configMsg14,
-  configMsg15,
-  configMsg16,
-  configMsg17,
-#ifdef MENU_PID_VEL
-  configMsg18,
-#endif
-};
-#endif
-
-const PROGMEM char * const menu_rc[] = 
-{   
-  #if defined CORRECT_MENU_RCT2
-    configMsg21,
-    configMsg22,
-    configMsg23a,
-    configMsg23b,
-    configMsg24,
-    configMsg25,
-    configMsg26,
-    configMsg27,
-  #elif defined CORRECT_MENU_RCT1 
-    configMsg21,
-    configMsg22,
-    configMsg23a,
-    configMsg23b,
-    configMsg24,
-    configMsg25,
-    configMsg26,
-    configMsg27,
-  #else //BF original / Cleanflight original / multiwii
-    configMsg21,
-    configMsg22,
-    configMsg23,
-    configMsg24,
-    configMsg25,
-    configMsg26,
-    configMsg27,
-  #endif
-
-};
-
-const PROGMEM char * const menu_bat[] = 
-{   
-  configMsg31,
-  configMsg32,
-  configMsg33,
-  configMsg34,
-  configMsg32,
-  configMsg36,
-  configMsgMWII,
-};
-
-const PROGMEM char * const menu_rssi[] = 
-{   
-  configMsg42,
-  configMsg43,
-  configMsgMWII,
-  configMsg46,
-  configMsg44,
-  configMsg45,
-};
-
-const PROGMEM char * const menu_amps[] = 
-{   
-  configMsg51,
-  configMsg52,
-  configMsg53,
-  configMsg54,
-  configMsg55,
-};
-
-const PROGMEM char * const menu_display[] = 
-{   
-  configMsg61,
-  configMsg62,
-  configMsg63,
-  configMsg64,
-  configMsg65,
-  configMsg66,
-  configMsg67,
-  configMsg68,
-};
-
-const PROGMEM char * const menu_advanced[] = 
-{   
-  configMsg71,
-  configMsg73,
-  configMsg74,
-  configMsg75,
-  configMsg76,
-  configMsg77,
-};
-
-const PROGMEM char * const menu_gps_time[] = 
-{   
-  configMsg81,
-  configMsg82,
-  configMsg83,
-};
-
-const PROGMEM char * const menu_alarm_item[] = 
-{   
-  configMsg91,
-  configMsg92,
-  configMsg93,
-  configMsg94,
-  configMsg95,
-  configMsg96,
-  configMsg97,
-};
-
-const PROGMEM char * const menu_profile[] = 
-{   
-  configMsg101,
-  configMsg102,
-  configMsg103,
-};
-
-const PROGMEM char * const menu_fixedwing_bf[] = 
-{   
-  configMsg111,
-  configMsg112,
-  configMsg113,
-  configMsg114,
-  configMsg115,
-  configMsg116,
-  configMsg117,
-  configMsg118,
-};
-
-const PROGMEM char * const menu_servo[] = 
-{   
-  configMsg121,
-  configMsg122,
-  configMsg123,
-  configMsg124,
-  configMsg125,
-  configMsg126,
-  configMsg127,
-  configMsg128,
-};
-
-const PROGMEM char * const menu_rc_2[] = 
-{   
-  configMsg131,
-  configMsg132,
-};
-
-const PROGMEM char * const menu_info[] = 
-{   
-  configMsg141,
-  configMsg142,
-  configMsg143,
-  configMsg144,
-  configMsg145,
-};
 
 const PROGMEM char * const menutitle_item[] = 
 {   
-#ifdef MENU_STAT
+#ifdef USE_MENU_STAT
   configMsg00,
 #endif
-#ifdef MENU_PID
+#ifdef USE_MENU_PID
   configMsg10,
 #endif
-#ifdef MENU_RC
+#ifdef USE_MENU_RC
   configMsg20,
 #endif
-#ifdef MENU_RC_2
+#ifdef USE_MENU_RC_2
   configMsg130,
 #endif
-#ifdef MENU_INFO
+#ifdef USE_MENU_INFO
   configMsg140,
 #endif
-#ifdef MENU_SERVO
+#ifdef USE_MENU_SERVO
   configMsg120,
 #endif
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
   configMsg110,
 #endif
-#ifdef MENU_VOLTAGE
+#ifdef USE_MENU_VOLTAGE
   configMsg30,
 #endif
-#ifdef MENU_RSSI
+#ifdef USE_MENU_RSSI
   configMsg40,
 #endif
-#ifdef MENU_CURRENT
+#ifdef USE_MENU_CURRENT
   configMsg50,
 #endif
-#ifdef MENU_DISPLAY
+#ifdef USE_MENU_DISPLAY
   configMsg60,
 #endif
-#ifdef MENU_ADVANCED
+#ifdef USE_MENU_ADVANCED
   configMsg70,
 #endif
-#ifdef MENU_GPS_TIME
+#ifdef USE_MENU_GPS_TIME
   configMsg80,
 #endif
-#ifdef MENU_ALARMS
+#ifdef USE_MENU_ALARMS
   configMsg90,
 #endif
-#ifdef MENU_PROFILE
+#ifdef USE_MENU_PROFILE
   configMsg100,
 #endif
-#ifdef MENU_VTX // always last
+#ifdef USE_MENU_VTX
   configMsg150,
 #endif
 };

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -395,7 +395,7 @@ void loop()
       case REQ_MSP_PID:
         MSPcmdsend = MSP_PID;
         break;
-#ifdef MENU_SERVO  
+#ifdef USE_MENU_SERVO  
       case REQ_MSP_SERVO_CONF:
         MSPcmdsend = MSP_SERVO_CONF;
         break;
@@ -441,7 +441,7 @@ void loop()
          MSPcmdsend = MSP_CONFIG;
       break;
 #endif
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
       case REQ_MSP_FW_CONFIG:
          MSPcmdsend = MSP_FW_CONFIG;
       break;
@@ -494,6 +494,7 @@ void loop()
       }
 #ifndef HIDESUMMARY
       if(previousarmedstatus && !armed){
+        configIndex=0;
         configPage=0;
         ROW=10;
         COL=1;
@@ -509,6 +510,7 @@ void loop()
       if(configMode)
       {
         displayConfigScreen();
+        displayDebug();
       }
 #ifdef CANVAS_SUPPORT
       else if (canvasMode)
@@ -829,10 +831,10 @@ void setMspRequests() {
 #ifdef HAS_ALARMS
       REQ_MSP_ALARMS|
 #endif
-#ifdef MENU_SERVO
+#ifdef USE_MENU_SERVO
       REQ_MSP_SERVO_CONF|
 #endif
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
       REQ_MSP_FW_CONFIG|
 #endif
       REQ_MSP_RC;

--- a/MW_OSD/RTC6705.ino
+++ b/MW_OSD/RTC6705.ino
@@ -58,33 +58,39 @@ void vtx_init() {
   vtxChannel = Settings[S_VTX_CHANNEL];
 
   vtx_set_frequency(vtxBand, vtxChannel);
+
+#ifdef FFPV_INNOVA
+  vtx_set_power(vtxPower);
+#endif
 }
+
 
 void vtx_transfer(int reg, int rw, uint32_t data)
 {
   uint32_t regdata = (reg << 0)|(rw << 4)|(data << 5);
+  uint32_t mask = 1;
+
+  // With ATmega328 running at 16MHz, we don't need any delay.
 
   _digitalLo(RTC_SPICLK);
   _digitalLo(RTC_SPILE);
 
-  for (int i = 0; i <25; i ++)
+  for (int i = 0; i < 25; i ++)
   {
 
-    if (regdata & ((uint32_t) 1 << i))
+    if (regdata & mask)
       _digitalHi(RTC_SPIDATA);
     else
       _digitalLo(RTC_SPIDATA);
-      
-    _delay_us (40);
 
     _digitalHi(RTC_SPICLK);
-    _delay_us (40);
 
     _digitalLo(RTC_SPICLK);
+
+    mask <<= 1;
   }
 
-  _delay_us (10);
-  _digitalLo(RTC_SPILE);
+  _digitalHi(RTC_SPILE);
 } 
 
 void vtx_set_power(uint8_t power)

--- a/MW_OSD/RTC6705.ino
+++ b/MW_OSD/RTC6705.ino
@@ -12,35 +12,7 @@
 # define VTX_PSW2_PIN 6
 # define VTX_LED_PIN  8
 
-// A6 is used for power sensing
-
-#if 0
-// SPILE = D15 (A1)
-#define CS_RBIT   _digital_pin_to_rbit(15)
-#define CS_PORT   _digital_pin_to_port(15)
-#define CS_DDR    _digital_pin_to_ddr(15)
-// SPICLK = D14 (A0)
-#define SCK_RBIT  _digital_pin_to_rbit(14)
-#define SCK_PORT  _digital_pin_to_port(14)
-#define SCK_DDR   _digital_pin_to_ddr(14)
-// SPIDATA = D16 (A2)
-#define MOSI_RBIT _digital_pin_to_rbit(16)
-#define MOSI_PORT _digital_pin_to_port(16)
-#define MOSI_DDR  _digital_pin_to_ddr(16)
-// PSW1 = D5
-# define PSW1_RBIT _digital_pin_to_rbit(5)
-# define PSW1_PORT _digital_pin_to_port(5)
-# define PSW1_DDR  _digital_pin_to_ddr(5)
-// PSW2 = D6
-# define PSW2_RBIT _digital_pin_to_rbit(6)
-# define PSW2_PORT _digital_pin_to_port(6)
-# define PSW2_DDR  _digital_pin_to_ddr(6)
-// VTXLED = D8
-# define VTXLED_RBIT _digital_pin_to_rbit(8)
-# define VTXLED_PORT _digital_pin_to_port(8)
-# define VTXLED_DDR  _digital_pin_to_ddr(8)
-#endif
-
+// Note: A6 is additionally used for power sensing
 
 #elif defined(FFPV_INNOVA)
 
@@ -48,90 +20,37 @@
 # define RTC_SPICLK   8
 # define RTC_SPIDATA 10
 
-#if 0
-// SPILE = D9
-#define CS_RBIT   _digital_pin_to_rbit(RTC_SPILE)
-#define CS_PORT   _digital_pin_to_port(RTC_SPILE)
-#define CS_DDR    _digital_pin_to_ddr(RTC_SPILE)
-// SPICLK = D8
-#define SCK_RBIT  _digital_pin_to_rbit(RTC_SPICLK)
-#define SCK_PORT  _digital_pin_to_port(RTC_SPICLK)
-#define SCK_DDR   _digital_pin_to_ddr(RTC_SPICLK)
-// SPIDATA = D10
-#define MOSI_RBIT _digital_pin_to_rbit(RTC_SPIDATA)
-#define MOSI_PORT _digital_pin_to_port(RTC_SPIDATA)
-#define MOSI_DDR  _digital_pin_to_ddr(RTC_SPIDATA)
-#endif
-
 #else
 # error Unknown VTX integrated board
 #endif
 
-#define CLR(x,y) (x&=(~(1<<y)))
-#define SET(x,y) (x|=(1<<y))
-#define TOGGLE(x,y) (x^=(1<<y))
-
 void vtx_init() {
 
-#if 1
   _pinModeOut(RTC_SPILE);
   _pinModeOut(RTC_SPICLK);
   _pinModeOut(RTC_SPIDATA);
-#else
-  CS_DDR |= (1 << CS_RBIT);
-  MOSI_DDR |= (1 << MOSI_RBIT);
-  SCK_DDR |= (1 << SCK_RBIT);
-#endif
 
 #ifdef IMPULSERC_HELIX
-
-#if 1
   _pinModeOut(VTX_PSW1_PIN);
   _pinModeOut(VTX_PSW2_PIN);
-#else
-  PSW1_DDR |= (1 << PSW1_RBIT);
-  PSW2_DDR |= (1 << PSW2_RBIT);
-#endif
-
 #endif
 
 #ifdef VTX_LED
-
-#if 1
   _pinModeOut(VTX_LED_PIN);
-#else
-  VTXLED_DDR |= (1 << VTXLED_RBIT);
-#endif
-
 #endif
 
   // CS high
-#if 1
   _digitalHi(RTC_SPILE);
-#else
-  SET(CS_PORT, CS_RBIT);
-#endif
 
 #ifdef IMPULSERC_HELIX
   // Low output power
-#if 1
   _digitalLo(VTX_PSW1_PIN);
   _digitalLo(VTX_PSW2_PIN);
-#else
-  CLR(PSW1_PORT, PSW1_RBIT);
-  CLR(PSW2_PORT, PSW2_RBIT);
-#endif
-
 #endif
 
 #ifdef VTX_LED
   // LED off
-#if 1
   _digitalHi(VTX_LED_PIN);
-#else
-  SET(VTXLED_PORT, VTXLED_RBIT);
-#endif
-
 #endif
 
   vtxPower = Settings[S_VTX_POWER];
@@ -145,50 +64,27 @@ void vtx_transfer(int reg, int rw, uint32_t data)
 {
   uint32_t regdata = (reg << 0)|(rw << 4)|(data << 5);
 
-#if 1
   _digitalLo(RTC_SPICLK);
   _digitalLo(RTC_SPILE);
-#else
-  CLR(SCK_PORT, SCK_RBIT);
-  CLR(CS_PORT, CS_RBIT);
-#endif
 
   for (int i = 0; i <25; i ++)
   {
 
     if (regdata & ((uint32_t) 1 << i))
-#if 1
       _digitalHi(RTC_SPIDATA);
-#else
-      SET(MOSI_PORT, MOSI_RBIT);
-#endif
     else
-#if 1
       _digitalLo(RTC_SPIDATA);
-#else
-      CLR(MOSI_PORT, MOSI_RBIT);
-#endif
       
     _delay_us (40);
-#if 1
+
     _digitalHi(RTC_SPICLK);
-#else
-    SET(SCK_PORT, SCK_RBIT);
-#endif
     _delay_us (40);
-#if 1
+
     _digitalLo(RTC_SPICLK);
-#else
-    CLR(SCK_PORT, SCK_RBIT);
-#endif
   }
 
   _delay_us (10);
-#if 1
   _digitalLo(RTC_SPILE);
-#else
-  SET(CS_PORT, CS_RBIT);
-#endif
 } 
 
 void vtx_set_power(uint8_t power)
@@ -196,31 +92,18 @@ void vtx_set_power(uint8_t power)
 #if defined(IMPULSERC_HELIX)
   switch (power) {
     case 0:
-#if 1
       _digitalLo(VTX_PSW1_PIN);
       _digitalLo(VTX_PSW2_PIN);
-#else
-      CLR(PSW1_PORT, PSW1_RBIT);
-      CLR(PSW2_PORT, PSW2_RBIT);
-#endif
       break;
+
     case 1:
-#if 1
       _digitalHi(VTX_PSW1_PIN);
       _digitalLo(VTX_PSW2_PIN);
-#else
-      SET(PSW1_PORT, PSW1_RBIT);
-      CLR(PSW2_PORT, PSW2_RBIT);
-#endif
       break;
+
     case 2:
-#if 1
       _digitalHi(VTX_PSW1_PIN);
       _digitalHi(VTX_PSW2_PIN);
-#else
-      SET(PSW1_PORT, PSW1_RBIT);
-      SET(PSW2_PORT, PSW2_RBIT);
-#endif
       break;
   }
 
@@ -241,8 +124,6 @@ void vtx_set_power(uint8_t power)
 #endif
 }
 
-//http://fpv-community.de/showthread.php?28337-RTC6705-Sender-auf-FatShark-Frequenz&p=844717&viewfull=1#post844717
-
 void vtx_set_frequency(uint8_t band, uint8_t channel)
 {
   uint16_t frequency = pgm_read_word(&vtx_frequencies[band][channel]);
@@ -253,7 +134,6 @@ void vtx_set_frequency(uint8_t band, uint8_t channel)
   uint8_t i = 0;
   if (frequency <5956 && frequency> 5644)
   {
-
     vtx_transfer(0, 1, 400);
     
     N = ((uint32_t) frequency * 25) / 64;
@@ -285,11 +165,8 @@ void vtx_toggle_led(uint32_t currentMillis)
 {
   if (ledToggle > 0 && (currentMillis - lastToggle) > 150)
   {
-#if 1
     _digitalToggle(VTX_LED_PIN);
-#else
-    TOGGLE(VTXLED_PORT, VTXLED_RBIT);
-#endif
+
     lastToggle = currentMillis;
     ledToggle--;
   }

--- a/MW_OSD/RTC6705.ino
+++ b/MW_OSD/RTC6705.ino
@@ -145,12 +145,6 @@ void vtx_set_frequency(uint8_t band, uint8_t channel)
   }
 }
 
-#ifdef IMPULSERC_HELIX
-bool powered = 1;
-bool wasPowered = 0;
-uint32_t debounce = 0;
-#endif
-
 #ifdef VTX_LED 
 uint16_t ledToggle = 0;
 uint32_t lastToggle = 0;
@@ -163,7 +157,7 @@ void vtx_flash_led(uint8_t count)
 
 void vtx_toggle_led(uint32_t currentMillis)
 {
-  if (ledToggle > 0 && (currentMillis - lastToggle) > 150)
+  if (ledToggle > 0 && (currentMillis - lastToggle) > 200)
   {
     _digitalToggle(VTX_LED_PIN);
 
@@ -179,6 +173,10 @@ void vtx_process_state(uint32_t currentMillis, uint8_t band, uint8_t channel)
 #ifdef VTX_LED
   vtx_toggle_led(currentMillis);
 #endif
+
+  static bool powered = 1;
+  static bool wasPowered = 0;
+  static uint32_t debounce = 0;
 
   bool reading = analogRead(A6) > 900 ? true : false;
 

--- a/MW_OSD/RTC6705.ino
+++ b/MW_OSD/RTC6705.ino
@@ -143,7 +143,7 @@ void vtx_init() {
 
 void vtx_transfer(int reg, int rw, uint32_t data)
 {
-  uint32_t regdata = (reg << 0)|(rw << 4)|data;
+  uint32_t regdata = (reg << 0)|(rw << 4)|(data << 5);
 
 #if 1
   _digitalLo(RTC_SPICLK);
@@ -254,13 +254,12 @@ void vtx_set_frequency(uint8_t band, uint8_t channel)
   if (frequency <5956 && frequency> 5644)
   {
 
-    data = 400 << 5;
-    vtx_transfer(0, 1, data);
+    vtx_transfer(0, 1, 400);
     
     N = ((uint32_t) frequency * 25) / 64;
     A = ((uint32_t) frequency * 25 - N * 64);
 
-    data = ((A & 0x7F) << 5) |  ((N & 0x1FFF) << 12);
+    data = (A & 0x7F) | ((N & 0x1FFF) << 7);
 
     vtx_transfer(1, 1, data);
   }

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1817,6 +1817,7 @@ void updateVtxStatus(void)
     MAX7456_WriteString(tmp, 12 + 30);
     MAX7456_WriteString(itoa(vtxChannel + 1, screenBuffer, 10), 14 + 30);
     MAX7456_WriteString_P(PGMSTR(&(vtxPowerNames[vtxPower])), 16 + 30);
+    MAX7456_WriteString(itoa((uint16_t)pgm_read_word(&vtx_frequencies[vtxBand][vtxChannel]), screenBuffer, 10), 20 + 30);
   }
 }
 #endif

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -1222,7 +1222,7 @@ void displayCursor(void)
   }
   if(ROW<10)
   {
-#ifdef MENU_VTX
+#ifdef USE_MENU_VTX
     if (configPage == MENU_VTX) {
       if (ROW==5) ROW=10;
       if (ROW==9) ROW=4;
@@ -1230,9 +1230,9 @@ void displayCursor(void)
     }
 #endif
 
-#ifdef MENU_PID
+#ifdef USE_MENU_PID
     if(configPage==MENU_PID){
-#ifdef MENU_PID_VEL
+#ifdef USE_MENU_PID_VEL
       if (ROW==9) {
         if (oldROW==8)
           ROW=10;
@@ -1248,7 +1248,7 @@ void displayCursor(void)
     }
 #endif
 
-#ifdef MENU_RC_2
+#ifdef USE_MENU_RC_2
     if(configPage==MENU_RC_2){
       if (ROW==3) ROW=10;
       if (ROW==9) ROW=2;
@@ -1257,7 +1257,7 @@ void displayCursor(void)
 #endif
 
 
-#ifdef MENU_RC
+#ifdef USE_MENU_RC
 #if defined CORRECT_MENU_RCT2
     if(configPage==MENU_RC){
       if (ROW==9){
@@ -1293,7 +1293,7 @@ void displayCursor(void)
 #endif
 
 #endif
-#ifdef MENU_SERVO
+#ifdef USE_MENU_SERVO
     if(configPage==MENU_SERVO){
       if (ROW==9){
         if (oldROW==8)
@@ -1307,7 +1307,7 @@ void displayCursor(void)
       if(COL==3) cursorpos=(ROW+2)*30+6+7+7;
     }
 #endif
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
     if(configPage==MENU_FIXEDWING){
       COL=3;
       if (ROW==9){
@@ -1320,7 +1320,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;     
     }
 #endif
-#ifdef MENU_VOLTAGE
+#ifdef USE_MENU_VOLTAGE
     if(configPage==MENU_VOLTAGE){
       COL=3;
       if (ROW==8) ROW=10;
@@ -1328,7 +1328,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;     
     }
 #endif
-#ifdef MENU_RSSI
+#ifdef USE_MENU_RSSI
     if(configPage==MENU_RSSI){
       COL=3;
       if (ROW==7) ROW=10;
@@ -1336,7 +1336,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }    
 #endif
-#ifdef MENU_CURRENT
+#ifdef USE_MENU_CURRENT
     if(configPage==MENU_CURRENT)
     {  
       COL=3;
@@ -1345,7 +1345,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }
 #endif
-#ifdef MENU_DISPLAY
+#ifdef USE_MENU_DISPLAY
     if(configPage==MENU_DISPLAY)
     {  
       if (ROW==9){
@@ -1359,7 +1359,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }
 #endif
-#ifdef MENU_ADVANCED
+#ifdef USE_MENU_ADVANCED
     if(configPage==MENU_ADVANCED)
     {  
       COL=3;
@@ -1368,7 +1368,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }
 #endif
-#ifdef MENU_GPS_TIME
+#ifdef USE_MENU_GPS_TIME
     if(configPage==MENU_GPS_TIME)
     {  
       COL=3;
@@ -1377,7 +1377,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }
 #endif     
-#ifdef MENU_ALARMS
+#ifdef USE_MENU_ALARMS
     if(configPage==MENU_ALARMS)
     {  
       COL=3;
@@ -1386,14 +1386,14 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }
 #endif     
-#ifdef MENU_INFO
+#ifdef USE_MENU_INFO
     if(configPage==MENU_INFO)
     {  
       COL=3;
       ROW=10;
     }
 #endif
-#ifdef MENU_PROFILE
+#ifdef USE_MENU_PROFILE
     if(configPage==MENU_PROFILE)
     {  
 #ifdef CORRECTLOOPTIME
@@ -1408,7 +1408,7 @@ void displayCursor(void)
       cursorpos=(ROW+2)*30+10+6+6;
     }
 #endif 
-#ifdef MENUVTX  
+#ifdef USE_MENUVTX  
     if(configPage==MENUVTX)
       {  
         COL=3;
@@ -1429,7 +1429,7 @@ void displayConfigScreen(void)
 {
   int16_t MenuBuffer[10];
   MAX7456_WriteString_P(PGMSTR(&(menutitle_item[configPage])),35);
-#ifdef MENU_PROFILE
+#ifdef USE_MENU_PROFILE
   //   MAX7456_WriteString(itoa(FCProfile,screenBuffer,10),50); // Display Profile number
 #endif 
   MAX7456_WriteString_P(configMsgEXT, SAVEP);    //EXIT
@@ -1438,7 +1438,9 @@ void displayConfigScreen(void)
     MAX7456_WriteString_P(configMsgPGS, SAVEP+16); //<Page>
   }
 
-  if(configPage==MENU_STAT)
+  debug[3] = configPage;
+
+  if(configPage == MENU_STAT)
   {
 
 #ifdef SHORTSUMMARY
@@ -1484,11 +1486,11 @@ void displayConfigScreen(void)
 #endif
 
   }
-#ifdef MENU_PID
+#ifdef USE_MENU_PID
   if(configPage==MENU_PID)
   {
 
-#ifdef MENU_PID_VEL
+#ifdef USE_MENU_PID_VEL
     for(uint8_t X=0; X<=7; X++)
 #else
     for(uint8_t X=0; X<=6; X++)
@@ -1501,7 +1503,7 @@ void displayConfigScreen(void)
 #endif
     }
    
-#ifdef MENU_PID_VEL
+#ifdef USE_MENU_PID_VEL
     for(uint8_t Y=0; Y<=9; Y++)
 #else
     for(uint8_t Y=0; Y<=8; Y++)
@@ -1522,7 +1524,7 @@ void displayConfigScreen(void)
     MAX7456_WriteString("D",83);
   }
 #endif
-#ifdef MENU_RC_2
+#ifdef USE_MENU_RC_2
   if(configPage==MENU_RC_2)
   {   
     MenuBuffer[0]=tpa_breakpoint16;
@@ -1533,7 +1535,7 @@ void displayConfigScreen(void)
     }
   }
 #endif
-#ifdef MENU_RC
+#ifdef USE_MENU_RC
   if(configPage==MENU_RC)
   {
 #if defined CORRECT_MENU_RCT2
@@ -1577,7 +1579,7 @@ void displayConfigScreen(void)
 #endif
   }
 #endif
-#ifdef MENU_SERVO
+#ifdef USE_MENU_SERVO
   if(configPage==MENU_SERVO)
   {
     MAX7456_WriteString("MIN",67);
@@ -1591,7 +1593,7 @@ void displayConfigScreen(void)
     }
   }
 #endif
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
   if(configPage==MENU_FIXEDWING)
   {
     MenuBuffer[0]=cfg.fw_gps_maxcorr;
@@ -1608,7 +1610,7 @@ void displayConfigScreen(void)
     }
   }
 #endif
-#ifdef MENU_VOLTAGE
+#ifdef USE_MENU_VOLTAGE
   if(configPage==MENU_VOLTAGE)
   {
     ProcessSensors();
@@ -1637,7 +1639,7 @@ void displayConfigScreen(void)
     Menuconfig_onoff(MAGD,S_MAINVOLTAGE_VBAT);
   }
 #endif
-#ifdef MENU_RSSI
+#ifdef USE_MENU_RSSI
   if(configPage==MENU_RSSI)
   {
     itoa(rssi,screenBuffer,10);
@@ -1661,7 +1663,7 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings16[S16_RSSIMIN],screenBuffer,10),LEVD);
   }
 #endif
-#ifdef MENU_CURRENT
+#ifdef USE_MENU_CURRENT
   if(configPage==MENU_CURRENT)
   {
     ItoaPadded(amperage, screenBuffer, 4, 3);     // 99.9 ampere max!
@@ -1679,7 +1681,7 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings16[S16_AMPZERO],screenBuffer,10),VELD);
   }
 #endif
-#ifdef MENU_DISPLAY
+#ifdef USE_MENU_DISPLAY
   if(configPage==MENU_DISPLAY)
   {
     for(uint8_t X=0; X<=7; X++) {
@@ -1695,7 +1697,7 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings[S_MAPMODE],screenBuffer,10),MAGD+LINE);
   }
 #endif
-#ifdef MENU_ADVANCED
+#ifdef USE_MENU_ADVANCED
   if(configPage==MENU_ADVANCED)
   {
     for(uint8_t X=0; X<=5; X++) {
@@ -1728,7 +1730,7 @@ void displayConfigScreen(void)
     Menuconfig_onoff(LEVD,S_THROTTLE_PWM);    
   }
 #endif
-#ifdef MENU_GPS_TIME
+#ifdef USE_MENU_GPS_TIME
   if(configPage==MENU_GPS_TIME)
   {
     for(uint8_t X=0; X<=2; X++) {
@@ -1739,7 +1741,7 @@ void displayConfigScreen(void)
     MAX7456_WriteString(itoa(Settings[S_GPSTZ],screenBuffer,10),YAWD);
   }    
 #endif  
-#ifdef MENU_ALARMS
+#ifdef USE_MENU_ALARMS
   if(configPage==MENU_ALARMS){
     MenuBuffer[0]=Settings[S_DISTANCE_ALARM];
     MenuBuffer[1]=Settings[S_ALTITUDE_ALARM];
@@ -1756,7 +1758,7 @@ void displayConfigScreen(void)
   }
 #endif  
 
-#ifdef MENU_PROFILE
+#ifdef USE_MENU_PROFILE
   if(configPage==MENU_PROFILE){
 #ifdef CORRECTLOOPTIME
 #define MENU10MAX 2
@@ -1773,7 +1775,7 @@ void displayConfigScreen(void)
   }
 #endif  
 
-#ifdef MENU_INFO
+#ifdef USE_MENU_INFO
   if(configPage==MENU_INFO){
     for(uint8_t X=0; X<=4; X++) {
       MAX7456_WriteString_P(PGMSTR(&(menu_info[X])), ROLLT+(X*30));
@@ -1781,7 +1783,7 @@ void displayConfigScreen(void)
   }
 #endif  
 
-#ifdef MENU_VTX
+#ifdef USE_MENU_VTX
   if(configPage == MENU_VTX) {
     for(uint8_t X=0; X<=2; X++)
       MAX7456_WriteString_P(PGMSTR(&(menu_vtx[X])), ROLLT+ (X*30));
@@ -1798,12 +1800,14 @@ void displayConfigScreen(void)
   }
 #endif
 
-  if(configPage > MAXPAGE)configPage=MINPAGE;
+  // XXX What is this for???
+  // XXX Remember to use configIndex if resurrecting.
+  //if(configPage > MAXPAGE)configPage=MINPAGE;
 
   displayCursor();
 }
 
-#ifdef MENU_VTX
+#ifdef USE_MENU_VTX
 void updateVtxStatus(void)
 {
   if (configPage == MENU_VTX) {

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -504,7 +504,7 @@ For sub-command 3 (draw string):
     MWAmperage = (int16_t)read16();
  }
 
-#ifdef MENU_SERVO  
+#ifdef USE_MENU_SERVO  
   if (cmdMSP==MSP_SERVO_CONF)
   {
     for (uint8_t i = 0; i < MAX_SERVOS; i++) {
@@ -519,7 +519,7 @@ For sub-command 3 (draw string):
  }
 #endif //MENU_SERVO   
 
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
   if (cmdMSP==MSP_FW_CONFIG)
   {
     cfg.fw_althold_dir=read8();
@@ -538,7 +538,7 @@ For sub-command 3 (draw string):
     }
     modeMSPRequests &=~ REQ_MSP_FW_CONFIG;
   }
-#endif // MENU_FIXEDWING
+#endif // USE_MENU_FIXEDWING
 
 #ifdef USE_FC_VOLTS_CONFIG
   if (cmdMSP==MSP_MISC)
@@ -632,7 +632,7 @@ For sub-command 3 (draw string):
       for(uint8_t i = 0; i<dataSize; i++) {
         c = read8();
 
-#ifdef MENU_PID_VEL
+#ifdef USE_MENU_PID_VEL
         if((pn_index != 5) && (pn_index != 6) && (pn_index <= 9)) // 5, 6 and >9 are skipped
 #else
         if((pn_index != 5) && (pn_index != 6) && (pn_index <= 8)) // 5, 6 and >8 are skipped
@@ -905,7 +905,8 @@ void handleRawRC() {
           // Enter config mode using stick combination
           waitStick =  2;	// Sticks must return to center before continue!
           configMode = 1;
-          configPage = previousconfigPage;
+          configIndex = previousConfigIndex;
+          configPage = menuConfig[configIndex];
           setMspRequests();
       }
     }
@@ -973,7 +974,7 @@ void handleRawRC() {
       { 
 	waitStick =1;
         menudir=1+oldmenudir;
-        #ifdef MENU_ALARMS
+        #ifdef USE_MENU_ALARMS
 	if(configPage == MENU_ALARMS && COL == 3) {
 	  if(ROW==5) timer.magCalibrationTimer=0;
         }
@@ -1004,14 +1005,20 @@ void serialMenuCommon()
     if (menudir < -1){
       menudir = -1;
     }
-//      constrain(menudir,-1,1);
-    configPage += menudir;
+
+    debug[0] = configIndex;
+
+    configIndex += menudir;
+
+    if (configIndex < MINPAGE) configIndex = MAXPAGE;
+    if (configIndex > MAXPAGE) configIndex = MINPAGE;
+    configPage = menuConfig[configIndex];
   }
 
-  if(configPage < MINPAGE) configPage = MAXPAGE;
-  if(configPage > MAXPAGE) configPage = MINPAGE;
+  debug[1] = configIndex;
+  debug[2] = configPage;
 
-#ifdef MENU_VTX
+#ifdef USE_MENU_VTX
   if (configPage == MENU_VTX) {
     switch(ROW) {
       case 1: // Power
@@ -1049,9 +1056,9 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_PID
+#ifdef USE_MENU_PID
   if(configPage == MENU_PID) {
-#ifdef MENU_PID_VEL
+#ifdef USE_MENU_PID_VEL
     if(ROW >= 1 && ROW <= 8) {
 #else
     if(ROW >= 1 && ROW <= 7) {
@@ -1069,7 +1076,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_RC_2
+#ifdef USE_MENU_RC_2
   if(configPage == MENU_RC_2 && COL == 3) {    
     switch(ROW) {
       case 1: tpa_breakpoint16 += menudir; break;
@@ -1078,7 +1085,7 @@ void serialMenuCommon()
   }
 #endif
   
-#ifdef MENU_SERVO
+#ifdef USE_MENU_SERVO
   if(configPage == MENU_SERVO) {
     switch(COL) {
       case 1: servo.settings[0][ROW-1]+= menudir; break;
@@ -1088,7 +1095,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_RC
+#ifdef USE_MENU_RC
   #if defined CORRECT_MENU_RCT2
     if (configPage == MENU_RC && COL == 3) {
       switch(ROW) {
@@ -1130,7 +1137,7 @@ void serialMenuCommon()
   #endif
 #endif
 
-#ifdef MENU_FIXEDWING
+#ifdef USE_MENU_FIXEDWING
   if (configPage == MENU_FIXEDWING && COL == 3) {
     switch(ROW) {
     case 1: cfg.fw_gps_maxcorr += menudir; break;
@@ -1145,7 +1152,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_VOLTAGE
+#ifdef USE_MENU_VOLTAGE
   if (configPage == MENU_VOLTAGE && COL == 3) {
     switch(ROW) {
     case 1: ReverseSetting(S_DISPLAYVOLTAGE)
@@ -1159,7 +1166,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_RSSI
+#ifdef USE_MENU_RSSI
   if (configPage == MENU_RSSI && COL == 3) {
     switch(ROW) {
     case 1: ReverseSetting(S_DISPLAYRSSI)
@@ -1172,7 +1179,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_CURRENT
+#ifdef USE_MENU_CURRENT
   if (configPage == MENU_CURRENT && COL == 3) {
     switch(ROW) {
     case 1: ReverseSetting(S_AMPERAGE)
@@ -1184,7 +1191,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_DISPLAY
+#ifdef USE_MENU_DISPLAY
   if (configPage == MENU_DISPLAY && COL == 3) {
     switch(ROW) {
     case 1: ReverseSetting(S_DISPLAY_HORIZON_BR)
@@ -1199,7 +1206,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_ADVANCED
+#ifdef USE_MENU_ADVANCED
   if (configPage == MENU_ADVANCED && COL == 3) {
     switch(ROW) {
     case 1: ReverseSetting(S_UNITSYSTEM)
@@ -1212,7 +1219,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_GPS_TIME
+#ifdef USE_MENU_GPS_TIME
   if (configPage == MENU_GPS_TIME && COL == 3) {
     switch(ROW) {
     case 1: ReverseSetting(S_GPSTIME);
@@ -1226,7 +1233,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_ALARMS
+#ifdef USE_MENU_ALARMS
   if (configPage == MENU_ALARMS && COL == 3) {
     switch(ROW) {
     case 1: ModifySetting(S_DISTANCE_ALARM)
@@ -1240,7 +1247,7 @@ void serialMenuCommon()
   }
 #endif
 
-#ifdef MENU_PROFILE
+#ifdef USE_MENU_PROFILE
   #ifdef ADVANCEDSAVE
     if (configPage == MENU_PROFILE && COL == 3) {
       switch(ROW) {
@@ -1265,7 +1272,7 @@ void serialMenuCommon()
 #endif  
 
   if (ROW == 10) {
-    previousconfigPage = configPage;
+    previousConfigIndex = configIndex;
     switch(COL) {
     case 1: configExit(); break;
     case 2: configSave(); break;
@@ -1407,7 +1414,7 @@ void serialMSPreceive(uint8_t loops)
 
 void configExit()
 {
-  configPage=1;
+  configIndex=1;
   ROW=10;
   COL=3;
   configMode=0;
@@ -1509,7 +1516,7 @@ void configSave()
   mspWriteChecksum();
 #endif
 
-#if defined MENU_FIXEDWING
+#if defined USE_MENU_FIXEDWING
   mspWriteRequest(MSP_SET_FW_CONFIG,38);
   mspWrite8(cfg.fw_althold_dir);
   mspWrite16(cfg.fw_gps_maxcorr);
@@ -1526,9 +1533,9 @@ void configSave()
     mspWrite16(0);
   }
   mspWriteChecksum();  
-#endif // MENU_FIXEDWING
+#endif // USE_MENU_FIXEDWING
 
-#ifdef MENU_SERVO  
+#ifdef USE_MENU_SERVO  
   mspWriteRequest(MSP_SET_SERVO_CONF,(9*MAX_SERVOS));
     for (uint8_t i = 0; i < MAX_SERVOS; i++) {
       for (uint8_t ii = 0; ii < 5; ii++) {
@@ -1542,9 +1549,9 @@ void configSave()
 #endif
 
 #if 0 // This is not necessary? vtxBand,vtxChannel&vtxPower are all in sync with corresponding Settings at the end of stick handling.
-#ifdef MENU_VTX
+#ifdef USE_MENU_VTX
   vtx_save();
-#endif //MENU_VTX  
+#endif // USE_MENU_VTX  
 #endif
 
   writeEEPROM();

--- a/MW_OSD/wireMacro.h
+++ b/MW_OSD/wireMacro.h
@@ -1,5 +1,9 @@
 #include <stdio.h>
-#define ATOMIC_BLOCK(how)
+//#define ATOMIC_BLOCK(how) // Enable this for compiler output testing
+
+#define ATOMIC_RESTORE_STATE ATOMIC_RESTORESTATE
+
+#define _xxxconcat(a,b) a ## b
 
 #define _dp2rbit0 0
 #define _dp2rbit1 1
@@ -22,7 +26,8 @@
 #define _dp2rbit18 4
 #define _dp2rbit19 5
 
-#define _digital_pin_to_rbit(n) _dp2rbit##n
+#define _digital_pin_to_rbit(n) _xxxconcat(_dp2rbit, n)
+#define _DTOB(n) _digital_pin_to_rbit(n)
 
 #define _BV(n) (1 << (n))
 
@@ -47,7 +52,7 @@
 #define _dp2bm18 _BV(4)
 #define _dp2bm19 _BV(5)
 
-#define _digital_pin_to_bit_mask(n) _dp2bm##n
+#define _digital_pin_to_bit_mask(n) _xxxconcat(_dp2bm, n)
 
 #define _dp2p0   D /* 0 */
 #define _dp2p1   D
@@ -72,22 +77,24 @@
 
 #define _dp2p(n) _dp2p ## n
 
-#define _xxxconcat(a,b) a ## b
 #define _digital_pin_to_xxx(reg, group) _xxxconcat(reg, group)
 #define _digital_pin_to_ddr(n) _digital_pin_to_xxx(DDR, _dp2p(n))
 #define _digital_pin_to_port(n) _digital_pin_to_xxx(PORT, _dp2p(n))
 
-#define _pinModeOut(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) {\
-  _digital_pin_to_ddr(pin) |= _digital_pin_to_bit_mask(pin);}
+#define _pinModeOut(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do {\
+  _digital_pin_to_ddr(pin) |= _digital_pin_to_bit_mask(pin);} while (false)
 
-#define _pinModeIn(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) {\
-  _digital_pin_to_ddr(pin) &= ~_digital_pin_to_bit_mask(pin);}
+#define _pinModeIn(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do {\
+  _digital_pin_to_ddr(pin) &= ~_digital_pin_to_bit_mask(pin);} while (false)
 
-#define _digitalHi(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) {\
-  _digital_pin_to_port(pin) |= _digital_pin_to_bit_mask(pin);}
+#define _digitalHi(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do {\
+  _digital_pin_to_port(pin) |= _digital_pin_to_bit_mask(pin);} while (false)
 
-#define _digitalLo(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) {\
-  _digital_pin_to_port(pin) & ~_digital_pin_to_bit_mask(pin);}
+#define _digitalLo(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do {\
+  _digital_pin_to_port(pin) &= ~_digital_pin_to_bit_mask(pin);} while (false)
+
+#define _digitalToggle(pin) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do {\
+  _digital_pin_to_port(pin) ^= _digital_pin_to_bit_mask(pin);} while (false)
 
 #define _dp2xbm0  (_BV(0) << 16) /* 0, port D */
 #define _dp2xbm1  (_BV(1) << 16)
@@ -113,17 +120,17 @@
 #define _digital_pin_to_extended_bit_mask(n) _dp2xbm ## n
 #define _xm_(n) _digital_pin_to_extended_bit_mask(n) // short hand
 
-#define _pinModeOutGroup(bm) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) { \
+#define _pinModeOutGroup(bm) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do { \
   if ((bm) & 0xff) { DDRB |= ((bm) & 0xff); } \
   if (((bm) >> 8) & 0xff) { DDRC |= (((bm) >> 8) & 0xff); } \
-  if (((bm) >> 16) & 0xff) { DDRD |= (((bm) >> 16) & 0xff); } }
+  if (((bm) >> 16) & 0xff) { DDRD |= (((bm) >> 16) & 0xff); } } while (false)
 
-#define _pinModeInGroup(bm) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) { \
+#define _pinModeInGroup(bm) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do { \
   if ((bm) & 0xff) { DDRB &= ~((bm) & 0xff); } \
   if (((bm) >> 8) & 0xff) { DDRC &= ~(((bm) >> 8) & 0xff); } \
-  if (((bm) >> 16) & 0xff) { DDRD &= ~(((bm) >> 16) & 0xff); } }
+  if (((bm) >> 16) & 0xff) { DDRD &= ~(((bm) >> 16) & 0xff); } } while (false)
 
-#define _pinModeIO(ibm, obm) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) { \
+#define _pinModeIO(ibm, obm) ATOMIC_BLOCK(ATOMIC_RESTORE_STATE) do { \
   DDRB = (DDRB & ~((ibm) & 0xff)) | ((obm) & 0xff);\
   DDRC = (DDRC & ~(((ibm) >> 8) & 0xff)) | (((obm) >> 8) & 0xff);\
-  DDRD = (DDRD & ~(((ibm) >> 16) & 0xff)) | (((obm) >> 16) & 0xff); }
+  DDRD = (DDRD & ~(((ibm) >> 16) & 0xff)) | (((obm) >> 16) & 0xff); } while (false)

--- a/MW_OSD/wireMacro.h
+++ b/MW_OSD/wireMacro.h
@@ -29,7 +29,9 @@
 #define _digital_pin_to_rbit(n) _xxxconcat(_dp2rbit, n)
 #define _DTOB(n) _digital_pin_to_rbit(n)
 
-#define _BV(n) (1 << (n))
+#ifndef _BV
+# define _BV(n) (1 << (n))
+#endif
 
 #define _dp2bm0  _BV(0) /* 0, port D */
 #define _dp2bm1  _BV(1)


### PR DESCRIPTION
PR status: Need review, especially on config menu def restructuring ( 03a97a1 )  @ShikOfTheRa What do you think?

- Bug fix
o Fixed `vtx_transfer` to do the final shifting, given `reg`, `rw` and `data`.
o  Modified `vtx_set_frequency` NOT to shift `data`.

- Finished refactoring using `wireMacro`.
o Better view of which pin is manipulated (may be not a big deal for non-Arduino based hw).

- Restructured config menu definition.
o Separated menu page usage conditionals from order they appear in the config menus.
o It (eventually) allow menu page reordering.
o Menu strings are reviewed and enclosed in the corresponding menu usage conditionals.