### PR TITLE
VTX mod 20170221

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -4,7 +4,7 @@
 
 /********************       OSD HARDWARE settings      *********************/
 //Choose ONLY ONE option:
-//#define MINIMOSD                  // Uncomment this if using standard MINIMOSD hardware (default)
+#define MINIMOSD                  // Uncomment this if using standard MINIMOSD hardware (default)
 //#define MICROMINIMOSD             // Uncomment this if using the MICRO MINIMOSD hardware
 //#define AEROMAX                   // Uncomment this if using MWOSD AEROMAX hardware
 //#define RTFQV1                    // Uncomment this if using standard RTFQ/Witespy V1.1 OSD, select this to correct for both swapped bat1/bat 2 and to also use alternative resistors / pinouts.  
@@ -14,7 +14,7 @@
 //#define AIRBOTMICRO               // Uncomment this if using an airbot MicroOSD
 //#define ANDROMEDA                 // Uncomment this if using an Andromeda (http://www.multiwiicopter.com/)
 //#define IMPULSERC_HELIX           // Uncomment this if using an ImpulseRC integrated OSD/VTX
-#define FFPV_INNOVA               // Uncomment this if using an ImpulseRC integrated OSD/VTX
+//#define FFPV_INNOVA               // Uncomment this if using an ImpulseRC integrated OSD/VTX
 
 // NOTE-some boards have swapped bat1/bat2 pins and alternative voltage measuring resistors
 // If having difficulties, first select default MINIMOSD as above, then use the following to correct: 
@@ -340,9 +340,6 @@
 // Regional RF frequency regulations: Choose ONLY ONE option:
 #define VTX_REGION_UNRESTRICTED                // Enable for all 40 channels
 //#define VTX_REGION_AUSTRALIA                   // Enable for AU legal channels and power level only
-
-// Direct stick commands for band/chan manipulation
-#define VTX_RC
 
 /********************  Advanced parameters  settings      *********************/
 // This is to enable rarely used advanced parameter saving. Off by default to minimise risk 

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -1095,7 +1095,7 @@ typedef enum {
   MENU_VTX,      // VTX
 #endif
   MENU_LAST,
-  MAXPAGE = MENU_VTX - 1
+  MAXPAGE = MENU_LAST - 1
 } menuId_e;
 
 uint8_t menuConfig[] = {


### PR DESCRIPTION
- Fixed dependency of MAXPAGE on MENU_VTX (which caused non-VTX platform build to fail)
- Removed freestanding VTX_RC select option (this should be a part of the VTX enabled platforms)