### PR TITLE
add defines for RCSWITCH_CH test conditions

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -248,7 +248,8 @@
 //#define TX_GS                     // Enable for Graupner/Spektrum (Only use for GPSOSD/NAZA/APM/PIXHAWK/MAVLINK)    
 //#define TX_M                      // Enable for Multiplex (Only use for GPSOSD/NAZA/APM/PIXHAWK/MAVLINK)
 //#define TX_HS                     // Enable for Hitec/Sanwa (Only use for GPSOSD/NAZA/APM/PIXHAWK/MAVLINK)
-
+#define TX_CHAN_MID 1400     //  test value for determining RC SWITCH MID position
+#define TX_CHAN_HIGH 1600    // test value for determining RC SWITCH HIGH position
 
 /********************       Airspeed Settings         ************************/
 // Completely UNTESTED for future integration of support for airspeed sensor

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -248,10 +248,10 @@ void loop()
     rcswitch_ch = Settings[S_RCWSWITCH_CH];
     screenlayout=0;
     if (Settings[S_RCWSWITCH]){
-      if (MwRcData[rcswitch_ch] > 1600){
+      if (MwRcData[rcswitch_ch] > TX_CHAN_HIGH){
         screenlayout=1;
       }
-      else if (MwRcData[rcswitch_ch] > 1400){
+      else if (MwRcData[rcswitch_ch] > TX_CHAN_MID){
         screenlayout=2;
       }
     } 


### PR DESCRIPTION
add user-configurable values for determining MID and HIGH positions for
layout switching via RCSWITCH_CH setting.

Some RX's offer coarse, non-linear values for channel outputs via toggle switches. 
Ex: OpenLRSng has the option of outputting 8CH+4 'switches' with 1000us range broken up into 4 sections, w/ 'mid' position being above 1600us. This fix provides flexibility in establishing L/M/H switch positions without having to hack into the code.