### PR TITLE
add config definitions for inverting numeric pitch & roll angles

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -219,6 +219,8 @@
 //#define I2CERROR 3                // Autodisplay Mutltiwii I2C errors if exceeds specified count 
 //#define NOTHROTTLESPACE           // Enable to remove space between throttle symbol and the data
 #define DISPLAY_PR                  // Display pitch / roll angles. Requires relevant layout ppositions to be enabled
+//#define INVERT_PITCH              // Invert the sign of the displayed numeric value for the pitch angle (ex: pitch up = positive )
+//#define INVERT_ROLL               // Invert the sign of the displayed numeric value for the roll angle (ex: roll right = negative )
 //#define FULLAHI                   // Enable to display a slightly longer AHI line
 //#define REVERSEAHI                // Reverse pitch / roll direction of AHI - for DJI / Eastern bloc OSD users
 //#define AHICORRECT 10             // Enable to adjust AHI on display to match horizon. -10 = -1 degree

--- a/MW_OSD/Screen.ino
+++ b/MW_OSD/Screen.ino
@@ -446,7 +446,12 @@ void displayHorizon(int rollAngle, int pitchAngle)
   screenBuffer[0]=0x50;
   int16_t xx=abs(pitchAngle/10);
   uint8_t offset=1;
-  if(pitchAngle<0) {
+#ifdef INVERT_PITCH
+  if(pitchAngle>0) 
+#else
+  if(pitchAngle<0)
+#endif	  
+  {
     screenBuffer[1]='-';
     offset++;
   }
@@ -456,7 +461,12 @@ void displayHorizon(int rollAngle, int pitchAngle)
   screenBuffer[0]=0x52;
   offset=1;
   xx=abs(rollAngle/10);
-  if(rollAngle<0) {
+#ifdef INVERT_ROLL
+  if(rollAngle>0) 
+#else
+  if(rollAngle<0) 
+#endif
+  {
     screenBuffer[1]='-';
     offset++;
   }


### PR DESCRIPTION
Some people (including myself) don't agree with the sign convention used on some FC's for pitch & roll (ex: pitching nose up produces a 'negative' pitch value, which is counter-intuitive).

Here's a simple patch to allow for flipping the signs of the pitch & roll angles displayed in OSD. It doesn't affect AHI-related routines that use raw pitch & roll values; it simply inverts the sign in the display.

(last PR was broken, tested, woking now)