### PR TITLE
send msp_voltage_meter_config request

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -1124,6 +1124,7 @@ const unsigned char UnitsIcon[8]={
 #define REQ_MSP_FW_CONFIG      (1L<<20) 
 #define REQ_MSP_PIDNAMES       (1L<<21)
 #define REQ_MSP_SERVO_CONF     (1L<<22)
+#define REQ_MSP_VOLTAGE_METER_CONFIG (1L<<23)
 // Menu selections
 const PROGMEM char * const menu_choice_unit[] =
 {   

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -444,6 +444,9 @@ void loop()
           MSPcmdsend = MSP_ALARMS;
       break;
 #endif
+      case REQ_MSP_VOLTAGE_METER_CONFIG:
+        MSPcmdsend = MSP_VOLTAGE_METER_CONFIG;
+        break;
     }
     
     if(!fontMode){
@@ -888,7 +891,11 @@ void setMspRequests() {
     modeMSPRequests |= REQ_MSP_ANALOG;
     
 #ifdef USE_FC_VOLTS_CONFIG
+  #if defined(CLEANFLIGHT) || defined(BETAFLIGHT)
+    modeMSPRequests |= REQ_MSP_VOLTAGE_METER_CONFIG;
+  #else
     modeMSPRequests |= REQ_MSP_MISC;
+  #endif
 #endif
 
   }


### PR DESCRIPTION
Add missing request sending for msp_voltage_meter_config (extends #410), related to #409.

What do you think about `#if defined(CLEANFLIGHT) || defined(BETAFLIGHT)`?  Or is `modeMSPRequests |= REQ_MSP_MISC |  REQ_MSP_VOLTAGE_METER_CONFIG;`  better?