### PR TITLE
Memory leak with KISS 1.3RC39b

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -2077,8 +2077,32 @@ const PROGMEM char * const KISS_mode_index[] =
 };
 
 #define ESC_FILTER 10
+#define KISS_GET_TELEMETRY 0x20
+
+// Indexes of informations in the serial protocol(8 bits)
+#define KISS_INDEX_THROTTLE 0 // INT 16
+#define KISS_INDEX_RC1 2 // INT 16
+#define KISS_INDEX_RC2 4 // INT 16
+#define KISS_INDEX_RC3 6 // INT 16
+#define KISS_INDEX_RC4 8 // INT 16
+#define KISS_INDEX_RC5 10 // INT 16
+#define KISS_INDEX_RC6 12 // INT 16
+#define KISS_INDEX_RC7 14 // INT 16
+#define KISS_INDEX_CURRENT_ARMED 16
+#define KISS_INDEX_LIPOVOLT 17 // INT 16
+#define KISS_INDEX_ANGLE0 31 // INT 16
+#define KISS_INDEX_ANGLE1 33 // INT 16
+#define KISS_INDEX_MODE 65
+#define KISS_INDEX_ESC1_AMP 87 // INT 16
+#define KISS_INDEX_ESC2_AMP 97 // INT 16
+#define KISS_INDEX_ESC3_AMP 107 // INT 16
+#define KISS_INDEX_ESC4_AMP 117 // INT 16
+#define KISS_INDEX_ESC5_AMP 127 // INT 16
+#define KISS_INDEX_ESC6_AMP 137 // INT 16
+#define KISS_INDEX_MAH 148 // INT 16
+
 #define KISSFRAMEINIT 5
-#define KISSFRAMELENGTH 165 // max frame size
+#define KISSFRAMELENGTH KISS_INDEX_MAH + 2 // Size of serial buffer defined with last index used
 uint8_t KISSserialBuffer[KISSFRAMELENGTH];
 
 // Vars

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -394,7 +394,7 @@ void loop()
       if (timer.GUI_active == 0) {
         mspWriteRequest(MSP_ATTITUDE, 0);
       }
-#endif // KISS
+#endif // PROTOCOL_MSP
     }
 #endif //MSP_SPEED_MED  
 #endif //GPSOSD
@@ -521,13 +521,13 @@ void loop()
 
     if (!fontMode) {
 #ifdef KISS
-      Serial.write(0x20);
+      Serial.write(KISS_GET_TELEMETRY);
 #elif defined SKYTRACK
       DrawSkytrack();
 #elif defined PROTOCOL_MSP
 #ifdef CANVAS_SUPPORT
       if (!canvasMode)
-#endif
+#endif // CANVAS_SUPPORT
       {
         if (MSPcmdsend != 0) {
 #ifdef MSPV2
@@ -535,7 +535,7 @@ void loop()
             mspV2WriteRequest(MSPcmdsend, 0);
           }
           else
-#endif
+#endif // MSPV2
           {
             mspWriteRequest(MSPcmdsend & 0xff, 0);
           }

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -7,6 +7,8 @@
   #define SERIALBUFFERSIZE 65
 #elif defined iNAV // 40 max in test
   #define SERIALBUFFERSIZE 65
+#elif defined KISS
+  #define SERIALBUFFERSIZE 65
 #else
   #define SERIALBUFFERSIZE 100
 #endif


### PR DESCRIPTION
Added memory protection if size of kiss informations or greater than buffer.

I just set indexes to simplify reading