### PR TITLE
Submenu for KISS configurations

### DIFF
--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -565,7 +565,7 @@
 #if defined(KISS)
   #undef INTRO_FC
   #define MENU_STAT
-  #define MENU_PID
+  #define MENU_KISS
   #define MENU_VOLTAGE
   #define MENU_RSSI
   #define MENU_CURRENT
@@ -717,6 +717,14 @@
   #define MENU_STAT MENU_STAT_tmp
   #undef MAXPAGE
   #define MAXPAGE MENU_STAT 
+#endif
+
+#ifdef MENU_KISS
+  const uint8_t MENU_KISS_tmp = MAXPAGE+1;
+  #undef  MENU_KISS
+  #define MENU_KISS MENU_KISS_tmp
+  #undef  MAXPAGE
+  #define MAXPAGE MENU_KISS 
 #endif
 
 #ifdef MENU_PID

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -517,28 +517,40 @@ void loop()
         MSPcmdsend = MSP2_INAV_AIR_SPEED;
         break;
 #endif
+#ifdef KISS
+      case REQ_MSP_KISS_PID:
+        MSPcmdsend = MSP_KISS_PID;
+        break;
+      case REQ_MSP_RATES:
+        MSPcmdsend = MSP_RATES;
+        break;
+      case REQ_MSP_KISS_SETTINGS:
+        MSPcmdsend = MSP_KISS_SETTINGS;
+        break;
+#endif
     }
 
     if (!fontMode) {
+#ifdef KISS
 #ifdef KISSGPS
       if (KISSgetcmd>3){
         serialKISSrequest(KISS_GET_GPS);
         KISSgetcmd=0;         
       }
-      else{
-        if (MSPcmdsend == MSP_PID) {
-          serialKISSrequest(KISS_GET_SETTINGS);
-        } else {
-          serialKISSrequest(KISS_GET_TELEMETRY);
-          KISSgetcmd++;    
-        }        
-      }
-#elif defined KISS
-      if (MSPcmdsend == MSP_PID) {
+      else
+#endif // KISSGPS
+      { // For else of KISSGPS
+      if (MSPcmdsend == MSP_KISS_PID) {
+        serialKISSrequest(KISS_GET_PIDS);
+      } else if (MSPcmdsend == MSP_KISS_SETTINGS){
         serialKISSrequest(KISS_GET_SETTINGS);
+      } else if (MSPcmdsend == MSP_RATES) {
+        serialKISSrequest(KISS_GET_RATES);
       } else {
         serialKISSrequest(KISS_GET_TELEMETRY);
+        KISSgetcmd++; 
       }
+      } // For else of KISSGPS
 #elif defined SKYTRACK
       DrawSkytrack();
 #elif defined PROTOCOL_MSP
@@ -951,6 +963,9 @@ void setMspRequests() {
   }
   else if (configMode) {
     modeMSPRequests =
+#ifdef KISS
+      REQ_MSP_KISS_SETTINGS |
+#endif // KISS
       REQ_MSP_STATUS |
       REQ_MSP_RAW_GPS |
       REQ_MSP_ATTITUDE |


### PR DESCRIPTION
Use a submenu because otherwise it would be necessary to completely reconfigure the card or send x commands.
Each category has its order for its configuration.