### PR TITLE
Update GlobalVariables.h

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -1010,12 +1010,9 @@ float amperagesum = 0;
 int16_t MWAmperage=0;
 
 // Rssi
-int16_t rssi =0;   // uint8_t ?
-int16_t oldrssi;   // uint8_t ?
+int16_t rssi = 0;
+int16_t oldrssi = 0;
 volatile int16_t pwmRSSI = 0;
-//int rssiADC=0;
-//int rssi_Int=0;
-
 
 // For Voltage
 uint16_t voltage=0;                      // its the value x10


### PR DESCRIPTION
Removed rssiADC and rssi_Int since:
* They last as comment in the code since 2015.
* I did not find any other comments/ code occurrences refering these variable names.

Removed the question comments about int8_t or int16_t for rssi values since it seems to be int16_t since 2015. I guess no one will actually switch it back and it seems more confusing than helpful to me.

Initialized oldrssi with 0 as default value like the other global variables are handled in this file.