### PR TITLE
Add Sentinel AAT module target

### DIFF
--- a/MW_OSD/Config.h
+++ b/MW_OSD/Config.h
@@ -65,6 +65,8 @@
 //#define LTM2ADSB                  // Uncomment for a LTM protocol to ADSB converter
 //#define UBLOX2ADSB                // Uncomment for a UBLOX protocol to ADSB converter
 //#define ESCOSD                    // Uncomment this if using ESC OSD - displays ESC TELEMETRY VALUES recieved on serial RX. Suitable for single ESC only.
+//#define SENTINELAAT_UBLOX         // Uncomment this to create a SENTINEL AAT module for use with other OSD using UBLOX GPS
+//#define SENTINELAAT_NMEA          // Uncomment this to create a SENTINEL AAT module for use with other OSD using NMEA GPS
 
 // old releases supported...
 //#define MULTIWII_V23              // Uncomment this if you are using MW versions 2.2/2.3

--- a/MW_OSD/Def.h
+++ b/MW_OSD/Def.h
@@ -686,6 +686,17 @@
   #define MENU_STAT
 #endif
 
+#if defined SENTINELAAT_UBLOX
+  #define GPSOSD_UBLOX
+  #define SENTINELAAT
+  #define INTRO_DELAY 0
+#endif
+#if defined SENTINELAAT_NMEA
+  #define GPSOSD_NMEA
+  #define SENTINELAAT
+  #define INTRO_DELAY 0  
+#endif
+
 #if defined GPSOSD_UBLOX_KK
   #define UBLOX
   #define KKAUDIOVARIO AUDIOPIN     // Enable this for audio vario. AUDIOPIN = D2 on AEROMAX hardware. Alternatively use A3 (RSSI) with other hardware  

--- a/MW_OSD/GPS.ino
+++ b/MW_OSD/GPS.ino
@@ -341,6 +341,9 @@ bool GPS_NMEA_newFrame(char c) {
       if (checksum == parity) {
         timer.packetcount++;
         frameOK = 1;
+#ifdef SENTINELAAT
+        sentinel.gpsdata = true;
+#endif // SENTINELAAT          
         if (frame == FRAME_GGA) {
           GPS_updateGGA();
         }
@@ -556,6 +559,10 @@ bool GPS_UBLOX_newFrame(uint8_t data) {
 
 bool UBLOX_parse_gps(void) {
   timer.packetcount++;
+#ifdef SENTINELAAT
+  sentinel.gpsdata = true;
+#endif // SENTINELAAT  
+
   switch (_msg_id) {
     case MSG_POSLLH:
       //i2c_dataset.time                = _buffer.posllh.time;

--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -328,6 +328,24 @@ struct __adsb {
 }
 adsb;
 
+#ifdef SENTINELAAT
+#define SENTINELTIMEOUT 4500 
+struct __sentinel {
+  bool     gpsdata = false;
+  bool     gpsdetected = false;
+  uint8_t  baud = 99;
+  uint16_t timeout = SENTINELTIMEOUT;
+  uint32_t timer_led=0;
+  uint32_t timer_maxreset = 0;
+  uint32_t timer_gpsdata = 0;
+  uint32_t timer_baudchange = 0;
+}
+sentinel;
+
+uint32_t SentinelBaud[] {115200,57600,9600,38400,19200,4800};
+#endif // SENTINELAAT
+
+
 #ifdef ADSBSTATION
 const char ADSBTitle[]    PROGMEM = "ADS-B SENSE AND AVOID";
 const char ADSBHeading[]  PROGMEM = "ICAO DIST ALT  HDG SPD";

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -336,7 +336,7 @@ void loop()
 {
   // It would be beneficial to run this every few seconds to identify and reset max7456 lockups from low voltages
   static uint32_t lastcheck;
-  if (millis() / 1000 == lastcheck){
+  if (millis() / 1000 > lastcheck){
     MAX7456CheckStatus();
     lastcheck = millis() / 1000;
   }
@@ -346,6 +346,72 @@ void loop()
     displayDebug();
     displayReady = true;
     true;    
+  } 
+  if (millis() > (vsync_timer + VSYNC_TIMEOUT))
+    MAX7456_DrawScreen();   
+}
+#elif defined SENTINELAAT
+void loop() // SENTINEL GPSOSD
+{
+  Settings[S_AAT] = 1;
+  serialMSPreceive(1);
+
+  // Max lockup detect.............
+  if (millis() > sentinel.timer_maxreset){
+    MAX7456CheckStatus();
+    sentinel.timer_maxreset = millis();
+  }
+
+// LED................
+  if (sentinel.gpsdetected == true){
+    sentinel.timer_led=millis();
+  }  
+  if ( millis() > (sentinel.timer_led + 1000)){
+    sentinel.timer_led=millis();
+  }
+  else if (millis() > (sentinel.timer_led+ 500)){
+    LEDOFF
+  }
+  else{
+    LEDON
+  }
+  
+  // Autodetect baud rate.............
+    if (millis() > sentinel.timer_gpsdata){
+      sentinel.gpsdetected = false;
+    }
+    if (sentinel.gpsdata == true){
+      sentinel.gpsdetected =true;
+      sentinel.timer_gpsdata=millis()+SENTINELTIMEOUT;    
+    }
+    sentinel.gpsdata = false; 
+
+    if (sentinel.gpsdetected == false){
+      if (sentinel.timeout > (SENTINELTIMEOUT)){
+        sentinel.timeout = 0;
+      }   
+      if (millis() > sentinel.timer_baudchange){
+        sentinel.baud++; 
+        if (sentinel.baud>5){
+          sentinel.baud = 0;
+          sentinel.timeout +=1500;
+        }          
+        serialMSPreceive(1);
+        Serial.begin(SentinelBaud[sentinel.baud]);
+        delay(10);
+        serialMSPreceive(1);     
+        sentinel.timer_baudchange = millis() + sentinel.timeout;
+      }
+    }
+
+  // Draw .............
+  if (displayReady != true){
+    displayAAT();
+    //displayDebug();
+    //displayGPSPosition();
+    //displayArmed();
+    //displayNumberOfSat();
+    displayReady = true;  
   } 
   if (millis() > (vsync_timer + VSYNC_TIMEOUT))
     MAX7456_DrawScreen();   


### PR DESCRIPTION
For use with other OSD
Provides GPS tracking for use with Sentinel AAT tracker
Auto detects GPS baud rate. 
Single wire from GPS required