### PR TITLE
KISS : request settings if needed

### DIFF
--- a/MW_OSD/GlobalVariables.h
+++ b/MW_OSD/GlobalVariables.h
@@ -918,6 +918,7 @@ static uint16_t vtxMaxPower = 0;
 static uint8_t vtxBand = 0;
 static uint8_t vtxChannel = 1;
 static bool kissMessageToRequest = false;
+static bool kissSettingsToRequest = false;
 #else
 static uint8_t pidP[PIDITEMS], pidI[PIDITEMS], pidD[PIDITEMS];
 static uint8_t rcRate8,rcExpo8;

--- a/MW_OSD/KISS.h
+++ b/MW_OSD/KISS.h
@@ -203,7 +203,7 @@ void kiss_sync_settings() {
   vtxLowPower = kissread_u16(KISS_SETTINGS_IDX_VTX_LOW_POWER);
   vtxMaxPower = kissread_u16(KISS_SETTINGS_IDX_VTX_MAX_POWER);
 
-  modeMSPRequests &=~ REQ_MSP_KISS_SETTINGS;
+  kissSettingsToRequest = false;
 }
 
 void kiss_message() {

--- a/MW_OSD/MW_OSD.ino
+++ b/MW_OSD/MW_OSD.ino
@@ -1145,8 +1145,11 @@ void setMspRequests() {
 #ifdef KISSGPS
       REQ_MSP_KISS_GPS |
 #endif
-      REQ_MSP_KISS_TELEMTRY |
-      REQ_MSP_KISS_SETTINGS;
+      REQ_MSP_KISS_TELEMTRY;
+    // The configuration is loaded at initialisation(If the version is not yet known) or if asked (navigation on KISS menu)
+    if (Kvar.version == 0 || kissSettingsToRequest) {
+      modeMSPRequests |= REQ_MSP_KISS_SETTINGS;
+    }
 
     if (kissMessageToRequest) {
       modeMSPRequests |= REQ_MSP_KISS_MESSAGE;
@@ -1199,7 +1202,7 @@ void setMspRequests() {
     }
     
     // If the version is not yet known, we request it
-    if (Kvar.version == 0) {
+    if (Kvar.version == 0 || kissSettingsToRequest) {
       modeMSPRequests |= REQ_MSP_KISS_SETTINGS;
     }
 #endif // Not KISS

--- a/MW_OSD/Serial.ino
+++ b/MW_OSD/Serial.ino
@@ -1109,6 +1109,10 @@ if((MwRcData[PITCHSTICK]>MAXSTICK)&&(MwRcData[YAWSTICK]>MAXSTICK)&&(MwRcData[THR
           waitStick =  2;	// Sticks must return to center before continue!
           configMode = 1;
           configPage = previousconfigPage;
+#ifdef KISS
+          // Before displaying the configuration, refresh the settings which will then be updated when navigating in the KISS sub-menu
+          kissSettingsToRequest = true;
+#endif
           setMspRequests();
       }
     }
@@ -1835,7 +1839,7 @@ void kissBack() {
   case SUBMENU_KISS_NOTCH_FILTERS:
   case SUBMENU_KISS_LPF:
   case SUBMENU_KISS_VTX:
-    modeMSPRequests |= REQ_MSP_KISS_SETTINGS;
+    kissSettingsToRequest = true;
     break;
   }
   subConfigPage = -1;


### PR DESCRIPTION
The configuration is permanently reloaded during the configuration and therefore one cannot edit the values (PID etc..)